### PR TITLE
fix: render `<style>` so the colors are in the server HTML

### DIFF
--- a/.changeset/quiet-cases-shave.md
+++ b/.changeset/quiet-cases-shave.md
@@ -1,0 +1,15 @@
+---
+"material-theme-builder": minor
+---
+
+`<Mcu>` renders its `<style>` instead of injecting it from an effect, so the
+colors are in the server-rendered HTML.
+
+Effects only run in the browser, so on an SSR/SSG page the `<style>` used to
+reach the client empty: every `--md-sys-color-*` was undefined for the first
+paint, and anything reading one painted with no color at all until hydration
+filled it in. Rendering the tag puts the CSS in the HTML the server sends, and
+React updates its content in place when `setMcuConfig` changes the theme.
+
+The tag now sits where `<Mcu>` is rather than in `document.head` — same `id`,
+same cascade, but worth knowing if you were querying `head` for it.

--- a/src/Mcu.context.tsx
+++ b/src/Mcu.context.tsx
@@ -2,12 +2,7 @@ import {
   hexFromArgb,
   type TonalPalette,
 } from "@material/material-color-utilities";
-import React, {
-  useCallback,
-  useInsertionEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   builder,
   type FigmaTokens,
@@ -76,20 +71,6 @@ export const McuProvider = ({
   }, [mcuConfig]);
 
   //
-  // <style>
-  //
-
-  useInsertionEffect(() => {
-    let tag = document.getElementById(styleId);
-    if (!tag) {
-      tag = document.createElement("style");
-      tag.id = styleId;
-      document.head.appendChild(tag);
-    }
-    tag.textContent = css;
-  }, [css, styleId]);
-
-  //
   // getMcuColor
   //
 
@@ -134,7 +115,26 @@ export const McuProvider = ({
     ],
   );
 
-  return <Provider value={value}>{children}</Provider>;
+  //
+  // <style>
+  //
+  // Rendered, not injected from an effect. An effect only ever runs in the
+  // browser, so a server-rendered page would ship with none of the variables
+  // defined and paint before hydration filled them in -- every color missing
+  // for that first frame. Rendering the tag puts the CSS in the HTML the
+  // server sends, and React updates its content in place when `setMcuConfig`
+  // changes the theme.
+  //
+  // Not `<style href precedence>`: React treats hoisted stylesheets as
+  // immutable and keyed by `href`, so a theme change would either be ignored
+  // or leak a new stylesheet per change.
+
+  return (
+    <Provider value={value}>
+      <style id={styleId} dangerouslySetInnerHTML={{ __html: css }} />
+      {children}
+    </Provider>
+  );
 };
 
 export { McuContext, useMcu };

--- a/src/Mcu.test.tsx
+++ b/src/Mcu.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it } from "vitest";
 import { Mcu } from "./Mcu";
 
@@ -95,5 +96,35 @@ describe("Mcu", () => {
     styleContent = styleTag?.textContent || "";
 
     expect(styleContent).not.toContain("--md-sys-color-brand");
+  });
+
+  it("should render the CSS variables into the server markup", () => {
+    // The whole point of rendering the <style> rather than injecting it from
+    // an effect: effects don't run on the server, so anything rendered there
+    // used to reach the browser with no colors at all and paint an unthemed
+    // first frame.
+    const html = renderToStaticMarkup(
+      <Mcu source="#6750A4">
+        <div>Test content</div>
+      </Mcu>,
+    );
+
+    const open = '<style id="mcu-styles">';
+    expect(html).toContain(open);
+
+    const css = html.slice(
+      html.indexOf(open) + open.length,
+      html.indexOf("</style>"),
+    );
+    expect(css).toContain("--md-sys-color-primary");
+    expect(css).toContain("--md-sys-color-surface");
+    // Light in :root, dark in .dark -- both halves have to be there, since
+    // the scheme is picked by a class the app sets before paint.
+    expect(css).toContain(":root {");
+    expect(css).toContain(".dark {");
+    // Rendered through `dangerouslySetInnerHTML`, not as children: React
+    // escapes text children, which would turn a `&` or `>` in a selector into
+    // an entity and break the sheet.
+    expect(css).not.toMatch(/&(amp|gt|lt|quot|#x27);/);
   });
 });


### PR DESCRIPTION
`<Mcu>` injects its `<style>` from `useInsertionEffect`. Effects only run in the browser, so on an SSR or SSG page the tag reaches the client empty: every `--md-sys-color-*` is undefined for the first paint, and anything reading one paints with no color at all until hydration fills it in.

It's live today — `docs.pmnd.rs` serves `<style id="mcu-styles"></style>` and 0 occurrences of `md-sys-color` across 6 MB of HTML:

```sh
curl -sL https://docs.pmnd.rs/react-three-fiber/getting-started/introduction \
  | grep -c 'md-sys-color'   # 0
```

It bites hardest on a static export, where the browser has the whole page and paints it long before any JS lands.

### The change

`McuProvider` renders the tag instead:

```diff
-  useInsertionEffect(() => {
-    let tag = document.getElementById(styleId);
-    …
-    tag.textContent = css;
-  }, [css, styleId]);
-
-  return <Provider value={value}>{children}</Provider>;
+  return (
+    <Provider value={value}>
+      <style id={styleId} dangerouslySetInnerHTML={{ __html: css }} />
+      {children}
+    </Provider>
+  );
```

`Mcu` is already `"use client"`, and Next renders client components on the server for the initial HTML — so the CSS ships in the markup, hydration matches (`css` is a pure function of the props), and `setMcuConfig` still works because React updates the tag's content on re-render.

Two things I deliberately didn't do:

- **`<style href precedence>`**, React 19's hoist-to-`<head>` API. React treats hoisted stylesheets as immutable and keyed by `href`, so a theme change would either be dropped or leak a new sheet per change. Wrong fit for a provider whose whole job is changing the sheet.
- **Keeping the tag in `document.head`.** A portal into `head` doesn't server-render, which is the bug. So the tag now sits where `<Mcu>` is — same `id`, same cascade, valid everywhere. That's the one observable behaviour change, hence a `minor`.

### Tests

`Mcu.test.tsx` gains a `renderToStaticMarkup` case asserting the CSS is in the server markup — both the `:root` and `.dark` halves — and that it isn't HTML-escaped (which is why it's `dangerouslySetInnerHTML` and not children: React escapes text children, and a `&` or `>` in a selector would come out as an entity).

Verified it fails on `main` and passes here. The two existing tests are untouched and still pass; they query `document.querySelector("#mcu-styles")`, which doesn't care where the tag lives.

`pnpm run lgtm` clean.

### Follow-up

This fixes the FOUC for `<Mcu>` users. Separately, `builder` still can't be called from a Server Component — `dist/index.js` carries a hoisted `"use client"` banner, so an RSC gets `Attempted to call builder() from the server but builder is on the client`, and generating the CSS at build time means shelling out to the CLI. Happy to send that as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
