### PR TITLE
feat: keep `"use client"` off the builder so RSC can call it

### DIFF
--- a/.changeset/olive-donkeys-jam.md
+++ b/.changeset/olive-donkeys-jam.md
@@ -1,0 +1,17 @@
+---
+"material-theme-builder": minor
+---
+
+`builder` is now callable from a React Server Component.
+
+`dist/index.js` carried a `"use client"` banner over the whole bundle, so any
+import from the package — `builder` included — was a client module. Calling it
+from a server component threw `Attempted to call builder() from the server but
+builder is on the client`, which left generating the CSS at build time to the
+CLI.
+
+The React surface is built into its own `dist/react.js`, which is where the
+directive lands now; `dist/index.js` re-exports it. Nothing moves in the public
+API: `builder`, `Mcu`, `useMcu` and `ExportButton` are all still imported from
+`material-theme-builder`, and importing `Mcu` into a server component still
+works — it becomes a client reference, as it did before.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ theme.toFlutter();
 theme.toShadcn();
 ```
 
+> [!NOTE]
+>
+> `builder` is server-safe. Only the React entry points (`Mcu`, `useMcu`,
+> `ExportButton`) carry `"use client"`, so you can call it from a
+> [React Server Component](https://react.dev/reference/rsc/server-components)
+> — handy to emit `toCss()` into the document yourself rather than let `<Mcu>`
+> do it on the client.
+
 ## CLI
 
 ```sh

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { ExportButton } from "./ExportButton";
 export { builder } from "./lib/builder";
-export { Mcu } from "./Mcu";
-export { useMcu } from "./Mcu.context";
+// Held external at build time so `dist/react.js` stays its own file and keeps
+// its own "use client" -- see tsup.config.ts.
+export { ExportButton, Mcu, useMcu } from "./react.js";

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,0 +1,8 @@
+// The React surface, built separately from `index.ts` so that the
+// `"use client"` banner lands on this bundle only. `index.ts` re-exports it
+// without inlining it, which keeps the directive intact and leaves `builder`
+// callable from a server component. See tsup.config.ts.
+
+export { ExportButton } from "./ExportButton";
+export { Mcu } from "./Mcu";
+export { useMcu } from "./Mcu.context";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,23 +1,46 @@
 import { copyFileSync } from "fs";
 import { defineConfig } from "tsup";
 
+// Three bundles rather than one, so that `"use client"` lands only on the
+// React surface:
+//
+//   dist/index.js   no directive -- `builder` is callable from a server
+//                   component; re-exports the React entry points, which a
+//                   framework turns into client references
+//   dist/react.js   "use client" -- Mcu, useMcu, ExportButton
+//   dist/cli.js     the CLI
+//
+// `dist/index.js` keeps `./react.js` external so esbuild leaves the import
+// alone instead of inlining the module and dropping its directive.
+
+const shared = {
+  format: ["esm"] as const,
+  outDir: "dist",
+  external: ["react", "react-dom"],
+  esbuildOptions(options: { jsx?: string }) {
+    options.jsx = "automatic";
+  },
+};
+
 export default defineConfig([
   {
+    ...shared,
     entryPoints: ["src/index.ts"],
-    format: ["esm"],
     dts: true,
-    outDir: "dist",
     clean: true,
-    external: ["react", "react-dom"],
-    banner: {
-      js: '"use client";',
-    },
-    esbuildOptions(options) {
-      options.jsx = "automatic";
-    },
+    external: [...shared.external, "./react.js"],
     onSuccess: async () => {
       // Copy tailwind.css to dist
       copyFileSync("src/tailwind.css", "dist/tailwind.css");
+    },
+  },
+  {
+    ...shared,
+    entryPoints: ["src/react.ts"],
+    dts: true,
+    clean: false,
+    banner: {
+      js: '"use client";',
     },
   },
   {


### PR DESCRIPTION
Stacked on #155.

`dist/index.js` carries a `"use client"` banner over the whole bundle, so every export is a client module — `builder` included. Calling it from a React Server Component throws:

```
Attempted to call builder() from the server but builder is on the client.
It's not possible to invoke a client function from the server, it can only be
rendered as a Component or passed to props of a Client Component.
```

Which means an app that wants the CSS in its server-rendered HTML can't just do `builder(source).toCss()` in a layout — it has to shell out to the CLI in a prebuild step. The banner is there for `<Mcu>`, and `builder` is caught in the blast radius.

### The change

`src/react.ts` becomes the React entry — `Mcu`, `useMcu`, `ExportButton` — and is built as its own bundle, which is the only one that gets the banner. `src/index.ts` keeps `./react.js` external so esbuild leaves the import alone instead of inlining the module and dropping its directive.

```
dist/index.js   33 KB, no directive   builder + re-export of ./react.js
dist/react.js  138 KB, "use client"   Mcu, useMcu, ExportButton
dist/cli.js                           unchanged
```

**The public API doesn't move.** `builder`, `Mcu`, `useMcu` and `ExportButton` are still all imported from `material-theme-builder`; no new subpath to learn, nothing to migrate. Importing `Mcu` into a *server* component keeps working too — `index.js` re-exports a module that carries the directive, so the framework resolves it to a client reference exactly as before.

### Verified against a real Next build

Minimal App Router app, `output: "export"`, `builder()` called at module scope in `app/layout.tsx` — i.e. a server component — and `<Mcu>` rendered from that same server component:

```tsx
import { builder, Mcu } from "material-theme-builder";

const mcuCss = builder("#5de4c7", { scheme: "tonalSpot" }).toCss();

export default function RootLayout({ children }) {
  return (
    <html lang="en">
      <body>
        <style id="ssr-mcu" dangerouslySetInnerHTML={{ __html: mcuCss }} />
        <Mcu source="#5de4c7">{children}</Mcu>
      </body>
    </html>
  );
}
```

- on `main`: `Attempted to call builder() from the server`, build fails at *Collecting page data*
- on this branch: builds, exports, and both style tags come out of `out/index.html` populated — 19 398 chars each, `--md-sys-color-primary` and the `.dark` half present in both. (The `#mcu-styles` one being non-empty is #155; the `#ssr-mcu` one is this PR.)

`pnpm run lgtm` clean — `attw` still 🟢 on all four resolution modes, 40 tests pass.

### README

A note under **Programmatic API** saying `builder` is server-safe, since that's the whole point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
