### PR TITLE
ci: fix the release pipeline (skip-ci marker + dispatch gate)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.2/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": true,
+  "commit": false,
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,8 @@ on:
   push:
     branches:
       - main
-  # Lets a release be re-run from the Actions tab. The changesets bot marks
-  # its version-PR commit skip-ci so pushes to `changeset-release/main` don't
-  # spin CI; squash-merging that PR carries the marker onto `main` and the
-  # publish never fires. Without this, the only way back is an empty commit.
+  # Escape hatch: re-run a release from the Actions tab when the push-triggered
+  # run didn't publish. Without it the only way back is an empty commit on main.
   workflow_dispatch:
 
 concurrency:
@@ -45,20 +43,23 @@ jobs:
       # Changeset
       #
 
+      # npm auth is npm trusted publishing (OIDC) — no NPM_TOKEN. The trusted
+      # publisher declared on npmjs.com names *this* workflow file, so moving or
+      # renaming it breaks publishing with ENEEDAUTH. Setting an NPM_TOKEN secret
+      # would also break it: changesets/action then writes an .npmrc and skips OIDC.
       - name: Create Release Pull Request or Publish
         id: changesets
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: changesets/action@v1
         with:
           publish: pnpm run release
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check version bump
         id: check
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: EndBug/version-check@v2
         with:
           diff-search: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - main
+  # Lets a release be re-run from the Actions tab. The changesets bot marks
+  # its version-PR commit skip-ci so pushes to `changeset-release/main` don't
+  # spin CI; squash-merging that PR carries the marker onto `main` and the
+  # publish never fires. Without this, the only way back is an empty commit.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
2.2.0 was versioned but never published. Two independent causes.

> Note: this description deliberately never spells out the skip-ci marker in
> full — GitHub matches it in commit messages, and squash bodies are built
> from those.

## 1. The version commit carried a skip-ci marker

`.changeset/config.json` had `"commit": true`, so the changesets **CLI** wrote the version commit itself, and its default message ends with that marker. Squash-merging the version PR copied the message onto `main` (`0bd658a`), CI never ran, and the publish never fired.

Every release before this one landed as a **merge** commit (`b8d80db Merge pull request #122 from abernier/changeset-release/main`), which kept the marker on the side branch — which is why this never bit before.

Fixed at the source: `"commit": false` hands the commit back to `changesets/action`, which writes a plain `Version Packages`. Squash-merge is now safe, no merge-strategy discipline required.

## 2. `ENEEDAUTH` on publish

Publishing uses **npm trusted publishing (OIDC)**, not a token — `NPM_TOKEN` doesn't exist as a repo secret, and 2.1.2 on npm is stamped `GitHub Actions <npm-oidc-no-reply@github.com>` with provenance.

npm binds a trusted publisher to an exact workflow **filename**. The SLSA provenance for 2.1.2 records:

```
"path": ".github/workflows/release.yml"
```

`release.yml` was deleted in `3dafd0d` (2026-03-01) when the changesets step was folded into `ci.yml`. Since then the OIDC `job_workflow_ref` claim no longer matches what npmjs.com expects, npm refuses the exchange, and `npm publish` falls through to no auth — `ENEEDAUTH`.

**This part is fixed outside the repo:** npmjs.com → `material-theme-builder` → Settings → Trusted Publisher → workflow filename `release.yml` → `ci.yml`.

Merging this PR pushes to `main` and publishes 2.2.0 — but only once that field is saved.

## Also in here

- `workflow_dispatch` as an escape hatch, **and** the gate to make it work: both release steps were `if: github.event_name == 'push'`, so a dispatched run would have skipped them.
- Dropped `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}`. It resolves to empty today, but if the secret were ever added, `changesets/action` would write an `.npmrc` and silently turn OIDC (and provenance) off.

## Not fixed here

The `figma-plugin` job reads `secrets.FIGMA_ACCESS_TOKEN` and `vars.FIGMA_PLUGIN_ID`; neither exists in this repo. It's gated on `changed == 'true'`, so it will fire on the next successful version bump and fail on an empty bearer token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
