### PR TITLE
feat: add `material-theme-builder/builder`, a React-free entry

### DIFF
--- a/.changeset/tidy-pears-argue.md
+++ b/.changeset/tidy-pears-argue.md
@@ -1,0 +1,21 @@
+---
+"material-theme-builder": minor
+---
+
+New `material-theme-builder/builder` export, for calling `builder` without
+shipping React to the client.
+
+2.2.0 made `builder` callable from a server component, but not free: the main
+entry re-exports the React components, and a framework that splits server and
+client graphs registers every export of a `"use client"` module it sees. So
+`import { builder } from "material-theme-builder"` in a Next.js server
+component still put `Mcu` and the color utilities in the browser bundle — 32 kB
+gzip, for a component the page never renders.
+
+The subpath doesn't reference the React entry at all. Measured on a Next
+`output: "export"` app that only calls `builder(...).toCss()` in its layout,
+switching the import drops the client bundle from 269 668 to 237 542 bytes
+gzip, with identical server-rendered CSS.
+
+Nothing changes for existing imports — `material-theme-builder` still exports
+`builder`, `Mcu`, `useMcu` and `ExportButton`.

--- a/README.md
+++ b/README.md
@@ -52,11 +52,23 @@ theme.toShadcn();
 
 > [!NOTE]
 >
-> `builder` is server-safe. Only the React entry points (`Mcu`, `useMcu`,
+> `builder` is server-safe: only the React entry points (`Mcu`, `useMcu`,
 > `ExportButton`) carry `"use client"`, so you can call it from a
 > [React Server Component](https://react.dev/reference/rsc/server-components)
 > — handy to emit `toCss()` into the document yourself rather than let `<Mcu>`
 > do it on the client.
+>
+> In that case import it from **`material-theme-builder/builder`**:
+>
+> ```ts
+> import { builder } from "material-theme-builder/builder";
+> ```
+>
+> The main entry re-exports the React components, and a framework that splits
+> server and client graphs registers every export of a `"use client"` module it
+> sees — so importing `builder` from `material-theme-builder` ships the React
+> bundle to the browser even in a server component that never renders `<Mcu>`.
+> The subpath doesn't reference it, and costs the client nothing.
 
 ## CLI
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./builder": {
+      "types": "./dist/builder.d.ts",
+      "import": "./dist/builder.js"
+    },
     "./tailwind.css": "./dist/tailwind.css"
   },
   "homepage": "https://github.com/abernier/material-theme-builder",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,0 +1,12 @@
+// The non-React surface, on its own entry point and exported as
+// `material-theme-builder/builder`.
+//
+// `index.ts` re-exports `./react.js`, which carries "use client". A framework
+// that splits server and client graphs registers every export of a client
+// module it sees, so importing `builder` from the barrel drags the React
+// bundle -- Mcu, the color utilities, all of it -- into the browser, even in a
+// server component that never renders `<Mcu>`. This entry doesn't touch
+// `./react.js`, so it costs the client nothing.
+
+export { builder } from "./lib/builder";
+export type { McuConfig } from "./lib/builder";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { builder } from "./lib/builder";
-// Held external at build time so `dist/react.js` stays its own file and keeps
-// its own "use client" -- see tsup.config.ts.
+export { builder } from "./builder.js";
+// Both held external at build time so each keeps its own file -- `react.js`
+// its "use client", `builder.js` the absence of one. See tsup.config.ts.
 export { ExportButton, Mcu, useMcu } from "./react.js";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,14 +4,18 @@ import { defineConfig } from "tsup";
 // Three bundles rather than one, so that `"use client"` lands only on the
 // React surface:
 //
-//   dist/index.js   no directive -- `builder` is callable from a server
-//                   component; re-exports the React entry points, which a
-//                   framework turns into client references
-//   dist/react.js   "use client" -- Mcu, useMcu, ExportButton
-//   dist/cli.js     the CLI
+//   dist/index.js    no directive -- re-exports the two below
+//   dist/builder.js  no directive -- `builder`, and nothing that pulls React
+//   dist/react.js    "use client" -- Mcu, useMcu, ExportButton
+//   dist/cli.js      the CLI
 //
-// `dist/index.js` keeps `./react.js` external so esbuild leaves the import
-// alone instead of inlining the module and dropping its directive.
+// `dist/index.js` keeps both re-exports external so esbuild leaves the imports
+// alone instead of inlining the modules and dropping `react.js`'s directive.
+//
+// The split is what makes `material-theme-builder/builder` cost the client
+// nothing: a framework that registers client references sees every export of
+// `react.js` through the barrel, so importing `builder` from `.` ships the
+// React bundle even when `<Mcu>` is never rendered.
 
 const shared = {
   format: ["esm"] as const,
@@ -28,11 +32,17 @@ export default defineConfig([
     entryPoints: ["src/index.ts"],
     dts: true,
     clean: true,
-    external: [...shared.external, "./react.js"],
+    external: [...shared.external, "./builder.js", "./react.js"],
     onSuccess: async () => {
       // Copy tailwind.css to dist
       copyFileSync("src/tailwind.css", "dist/tailwind.css");
     },
+  },
+  {
+    ...shared,
+    entryPoints: ["src/builder.ts"],
+    dts: true,
+    clean: false,
   },
   {
     ...shared,


### PR DESCRIPTION
Follow-up to #156, which didn't finish the job.

#156 made `builder` *callable* from a server component. It didn't make it *free*: `dist/index.js` re-exports `./react.js`, and a framework that splits server and client graphs registers every export of a `"use client"` module it sees. So a Next.js server component doing nothing but

```tsx
import { builder } from "material-theme-builder";
const css = builder("#5de4c7").toCss();
```

still ships `Mcu` and `@material/material-color-utilities` to the browser, for a component the page never renders.

### Measured

A minimal Next `output: "export"` app whose layout only calls `builder(...).toCss()` and renders the result into a `<style>`. `<Mcu>` is never imported.

| import | client chunks (gzip) | `mcu-styles` / `tonalSpot` in them | SSR'd CSS |
|---|---|---|---|
| `material-theme-builder` | 269 668 | present | 19 398 chars |
| `material-theme-builder/builder` | **237 542** | **absent** | 19 398 chars |

-32 126 bytes gzip, byte-identical output.

### The change

`src/builder.ts` is the new entry -- `builder` and `McuConfig`, nothing that reaches React. `src/index.ts` re-exports it alongside `./react.js`, both held external in the index build, so the three stay separate files:

```
dist/index.js     167 B   no directive -- re-exports the two below
dist/builder.js    33 KB  no directive -- builder
dist/react.js     138 KB  "use client" -- Mcu, useMcu, ExportButton
```

**Nothing changes for existing imports.** `material-theme-builder` still exports `builder`, `Mcu`, `useMcu` and `ExportButton`; the subpath is purely additive. `attw` is green on all four resolution modes for all three entries, 40 tests pass, `pnpm run lgtm` clean.

### README

The note added in #156 now points at the subpath and says why, since "server-safe" on its own was misleading -- it was true of the call and false of the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
