### PR TITLE
feat!: move the React bindings to `material-theme-builder/react`

### DIFF
--- a/.changeset/olive-cups-shave.md
+++ b/.changeset/olive-cups-shave.md
@@ -1,0 +1,60 @@
+---
+"material-theme-builder": major
+---
+
+**Breaking:** the React bindings moved to `material-theme-builder/react`. The
+package root now holds `builder` alone.
+
+### Migration
+
+Change the import path for `Mcu`, `useMcu` and `ExportButton`:
+
+```diff
+- import { Mcu, useMcu, ExportButton } from "material-theme-builder";
++ import { Mcu, useMcu, ExportButton } from "material-theme-builder/react";
+```
+
+`builder` is unchanged — it stays on the root:
+
+```ts
+import { builder } from "material-theme-builder"; // unchanged
+```
+
+Both can be mixed freely; importing from each entry in the same file is fine.
+`material-theme-builder/tailwind.css` and the CLI are untouched. The root also
+now exports the `McuConfig` type, which was previously unreachable.
+
+### Why
+
+2.2.0 made `builder` callable from a server component, but not free. The root
+entry re-exported the React components, and a framework that splits server and
+client graphs registers every export of a `"use client"` module it reaches —
+re-export included, and tree-shaking can't undo it. So this:
+
+```tsx
+import { builder } from "material-theme-builder";
+const css = builder("#5de4c7").toCss();
+```
+
+still shipped `Mcu` and the color utilities to the browser in a server
+component that never renders `<Mcu>`.
+
+Measured on a Next `output: "export"` app whose layout does nothing but call
+`builder(...).toCss()` and render it into a `<style>`, same app source on both
+sides, only the package shape differing:
+
+|       | client chunks (gzip) | chunk files | `tonalSpot` in them | SSR'd CSS    |
+| ----- | -------------------- | ----------- | ------------------- | ------------ |
+| 2.2.0 | 198 715              | 9           | present             | 19 398 chars |
+| 3.0.0 | **166 679**          | 8           | **absent**          | 19 398 chars |
+
+−32 036 bytes gzip, byte-identical output. The saving exceeds what
+`dist/react.js` weighs on its own (26 184 gzip) because dropping it also
+collapses a whole chunk.
+
+A subpath for the React-free half would have fixed the bundle while leaving the
+default import the expensive one: you'd have to know about client-reference
+registration to reach for it. Putting the framework-agnostic core at the root
+and the bindings behind `/react` makes the cheap path the default, and matches
+how the ecosystem splits this elsewhere (`motion` / `motion/react`,
+`@floating-ui/dom` / `@floating-ui/react`).

--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ theme.toShadcn();
 
 > [!NOTE]
 >
-> `builder` is server-safe. Only the React entry points (`Mcu`, `useMcu`,
-> `ExportButton`) carry `"use client"`, so you can call it from a
+> The root entry costs a client bundle nothing. It holds `builder` alone — the
+> React bindings live at [`material-theme-builder/react`](#react) and are the
+> only thing carrying `"use client"`. So you can call `builder` from a
 > [React Server Component](https://react.dev/reference/rsc/server-components)
-> — handy to emit `toCss()` into the document yourself rather than let `<Mcu>`
-> do it on the client.
+> and emit `toCss()` into the document yourself, rather than let `<Mcu>` do it
+> on the client, without shipping React components the page never renders.
 
 ## CLI
 
@@ -70,10 +71,12 @@ See `npx material-theme-builder --help` for all available options.
 
 ## React
 
+The React bindings live on their own entry point, `material-theme-builder/react`.
+
 CSS variables are injected into the page:
 
 ```tsx
-import { Mcu } from "material-theme-builder";
+import { Mcu } from "material-theme-builder/react";
 
 <Mcu
   source="#0e1216"
@@ -112,7 +115,7 @@ import { Mcu } from "material-theme-builder";
 A hook is also provided:
 
 ```tsx
-import { useMcu } from "material-theme-builder";
+import { useMcu } from "material-theme-builder/react";
 
 const { initials, setMcuConfig, getMcuColor } = useMcu();
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js"
+    },
     "./tailwind.css": "./dist/tailwind.css"
   },
   "homepage": "https://github.com/abernier/material-theme-builder",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
+// The package root: `builder`, and nothing that reaches React.
+//
+// The React bindings live at `material-theme-builder/react` (src/react.ts).
+// Keeping them out of this barrel is the whole point: a framework that splits
+// server and client graphs registers every export of a `"use client"` module
+// it sees, including through a re-export. While this file re-exported them,
+// `import { builder } from "material-theme-builder"` in a server component
+// still shipped `Mcu` and the color utilities to the browser, for a component
+// the page never rendered.
+
 export { builder } from "./lib/builder";
-// Held external at build time so `dist/react.js` stays its own file and keeps
-// its own "use client" -- see tsup.config.ts.
-export { ExportButton, Mcu, useMcu } from "./react.js";
+export type { McuConfig } from "./lib/builder";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,16 +2,17 @@ import { copyFileSync } from "fs";
 import { defineConfig } from "tsup";
 
 // Three bundles rather than one, so that `"use client"` lands only on the
-// React surface:
+// React surface -- and so that nothing on the root entry points at it:
 //
-//   dist/index.js   no directive -- `builder` is callable from a server
-//                   component; re-exports the React entry points, which a
-//                   framework turns into client references
+//   dist/index.js   no directive -- `builder`, the package root
 //   dist/react.js   "use client" -- Mcu, useMcu, ExportButton
 //   dist/cli.js     the CLI
 //
-// `dist/index.js` keeps `./react.js` external so esbuild leaves the import
-// alone instead of inlining the module and dropping its directive.
+// The two are independent: `index.js` does not import `react.js`, which is
+// what keeps `import { builder } from "material-theme-builder"` free of React
+// in a client bundle. A framework that splits server and client graphs
+// registers every export of a client module it reaches, re-export included,
+// so a barrel spanning both surfaces cannot be tree-shaken back apart.
 
 const shared = {
   format: ["esm"] as const,
@@ -28,7 +29,6 @@ export default defineConfig([
     entryPoints: ["src/index.ts"],
     dts: true,
     clean: true,
-    external: [...shared.external, "./react.js"],
     onSuccess: async () => {
       // Copy tailwind.css to dist
       copyFileSync("src/tailwind.css", "dist/tailwind.css");


### PR DESCRIPTION
Supersedes #160, same problem, opposite shape.

#160 was right about the diagnosis and the measurement — I reproduced both. It added `material-theme-builder/builder` as a React-free subpath. This does the inversion instead: the framework-agnostic core stays at the root, the React bindings move behind `/react`.

```diff
- import { Mcu, useMcu, ExportButton } from "material-theme-builder";
+ import { Mcu, useMcu, ExportButton } from "material-theme-builder/react";

  import { builder } from "material-theme-builder";  // unchanged
```

### Why this way round

A subpath for the React-free half fixes the bundle but leaves the *default* import the expensive one — you'd have to know that a framework registers client references through a re-export to think of reaching for it. Since that's now the second pass on the same invariant (#156, then #160), removing the required knowledge beats documenting the workaround.

It also stops the package name from stuttering: `material-theme-builder/builder` on a package called `material-theme-builder` is a sign the root holds something other than what it says. And it's how the ecosystem splits this — `motion` / `motion/react`, `@floating-ui/dom` / `@floating-ui/react`.

### Measured

Next `output: "export"` app, layout does nothing but `builder(...).toCss()` into a `<style>`, `<Mcu>` never imported. Identical app source on both sides; only the installed package shape differs (published 2.2.0 vs this branch, packed).

| | client chunks (gzip) | chunk files | `tonalSpot` present | SSR'd CSS |
|---|---|---|---|---|
| 2.2.0 | 198 715 | 9 | yes | 19 398 chars |
| this branch | **166 679** | 8 | **no** | 19 398 chars |

−32 036 bytes gzip, byte-identical output. Within 90 bytes of #160's figure, measured on a different app — the mechanism reproduces.

Worth noting the saving is larger than `dist/react.js` weighs standalone (26 184 gzip): dropping it also collapses a whole chunk. I'd flagged that arithmetic as suspicious when reviewing #160; it holds up.

### Build

`dist/index.js` no longer references `./react.js` at all, so the index build stops holding it external:

```
dist/index.js   33 KB   no directive -- builder, zero occurrences of "react"
dist/react.js  138 KB   "use client" -- Mcu, useMcu, ExportButton
dist/cli.js     36 KB   the CLI
```

`attw` 🟢 on all four resolution modes for all three entries, 40 tests pass, `pnpm run lgtm` clean.

### Also

The root now exports the `McuConfig` type, which was previously unreachable from any entry point — it was declared in `react.d.ts` but never exported, and the root only re-exported `builder`.

### Left alone

`dist/react.js` still carries its own copy of the builder and `@material/material-color-utilities` (`argbFromHex` ×12, `TonalPalette` ×10 in both bundles). Pre-existing, unchanged by this PR, and only costs anything to a client component importing `builder` from the root *and* rendering `<Mcu>`. Deduping needs the React sources to import through the root entry, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
