### PR TITLE
feat: rename the `Mcu` component to `Mtb`, deprecate `Mcu`

### DIFF
--- a/.changeset/mcu-renamed-mtb.md
+++ b/.changeset/mcu-renamed-mtb.md
@@ -1,0 +1,5 @@
+---
+"material-theme-builder": minor
+---
+
+Rename the `Mcu` component to `Mtb`. `Mcu` still works as a deprecated alias of `Mtb` (same component, same props) and will be removed in the next major.

--- a/figma-plugin/src/main.tsx
+++ b/figma-plugin/src/main.tsx
@@ -3,8 +3,8 @@ import { createRoot } from "react-dom/client";
 import { Fab } from "../../src/components/m3/Fab";
 import { FlowfieldSt } from "../../src/Flowfield.stories";
 import { FlowfieldScene } from "../../src/Flowfield.stories.helpers";
-import { Mcu } from "../../src/Mcu";
 import { useMcu } from "../../src/Mcu.context";
+import { Mtb } from "../../src/Mtb";
 
 import { TooltipProvider } from "../../src/components/ui/tooltip";
 import "../../src/styles/globals.css";
@@ -62,13 +62,13 @@ function SyncButton() {
 function App() {
   return (
     <TooltipProvider>
-      <Mcu source="#769CDF" contrast={0}>
+      <Mtb source="#769CDF" contrast={0}>
         <FlowfieldScene {...FlowfieldSt.args} />
         <SyncButton />
         {/* <Layout notext noExport>
           <Scheme />
         </Layout> */}
-      </Mcu>
+      </Mtb>
     </TooltipProvider>
   );
 }

--- a/src/Flowfield.stories.tsx
+++ b/src/Flowfield.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Flowfield } from "./Flowfield";
 import { FlowfieldScene } from "./Flowfield.stories.helpers";
-import { Mcu } from "./Mcu";
+import { Mtb } from "./Mtb";
 
 const customColor1 = "#00D68A";
 const customColor2 = "#FFE16B";
@@ -40,7 +40,7 @@ export const FlowfieldSt: StoryObj<typeof Flowfield> = {
     smoothing: { control: { type: "range", min: 0, max: 10, step: 1 } },
   },
   render: (args) => (
-    <Mcu
+    <Mtb
       source="#769CDF"
       customColors={[
         { name: "myCustomColor1", hex: customColor1, blend: true },
@@ -50,6 +50,6 @@ export const FlowfieldSt: StoryObj<typeof Flowfield> = {
       <div className="h-dvh">
         <FlowfieldScene {...args} />
       </div>
-    </Mcu>
+    </Mtb>
   ),
 };

--- a/src/Mtb.stories.helpers.tsx
+++ b/src/Mtb.stories.helpers.tsx
@@ -4,8 +4,8 @@ import { type ComponentProps } from "react";
 import { ExportButton } from "./ExportButton";
 import { STANDARD_TONES } from "./lib/builder";
 import { cn } from "./lib/utils";
-import type { Mcu } from "./Mcu";
 import { useMcu } from "./Mcu.context";
+import type { Mtb } from "./Mtb";
 
 function Foo({ children, ...props }: ComponentProps<"div">) {
   return (
@@ -113,8 +113,8 @@ export function Scheme({
 }: {
   /** Heading displayed above the scheme. */
   title?: string;
-  /** Custom colors forwarded to the inner `<Mcu>`. */
-  customColors?: ComponentProps<typeof Mcu>["customColors"];
+  /** Custom colors forwarded to the inner `<Mtb>`. */
+  customColors?: ComponentProps<typeof Mtb>["customColors"];
 } & VariantProps<typeof schemeVariants> &
   Omit<ComponentProps<"div">, "title">) {
   return (
@@ -504,8 +504,8 @@ export function Shades({
 }: {
   /** Hide the palette group titles. */
   noTitle?: boolean;
-  /** Custom colors forwarded to the inner `<Mcu>`. */
-  customColors?: ComponentProps<typeof Mcu>["customColors"];
+  /** Custom colors forwarded to the inner `<Mtb>`. */
+  customColors?: ComponentProps<typeof Mtb>["customColors"];
 }) {
   return (
     <div className="flex flex-col gap-(--gap2)">

--- a/src/Mtb.stories.tsx
+++ b/src/Mtb.stories.tsx
@@ -3,15 +3,15 @@ import { useMemo } from "react";
 import { allModes } from "../.storybook/modes";
 import { type McuConfig, schemeNames } from "./lib/builder";
 import { recolorizeSvg } from "./lib/recolorizeSvg";
-import { Mcu } from "./Mcu";
 import { useMcu } from "./Mcu.context";
-import { Layout, Scheme, Shades, TailwindScheme } from "./Mcu.stories.helpers";
+import { Mtb } from "./Mtb";
+import { Layout, Scheme, Shades, TailwindScheme } from "./Mtb.stories.helpers";
 
 import exampleSvg from "./assets/example.svg?raw";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
-  component: Mcu,
+  component: Mtb,
   parameters: {
     // layout: "centered",
     chromatic: {
@@ -74,7 +74,7 @@ const meta = {
       table: { disable: true }, // hide
     },
   },
-} satisfies Meta<typeof Mcu>;
+} satisfies Meta<typeof Mtb>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -92,13 +92,13 @@ export const St2: Story = {
     contrast: 0,
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout notext>
         <Scheme customColors={args.customColors}>
           <Shades customColors={args.customColors} noTitle />
         </Scheme>
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -108,7 +108,7 @@ export const St1: Story = {
     source: "#769CDF",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -123,7 +123,7 @@ export const St1: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -142,7 +142,7 @@ export const MonochromeSt: Story = {
     scheme: "monochrome",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -157,7 +157,7 @@ export const MonochromeSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -168,7 +168,7 @@ export const NeutralSt: Story = {
     scheme: "neutral",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -183,7 +183,7 @@ export const NeutralSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -194,7 +194,7 @@ export const VibrantSt: Story = {
     scheme: "vibrant",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -209,7 +209,7 @@ export const VibrantSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -220,7 +220,7 @@ export const ExpressiveSt: Story = {
     scheme: "expressive",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -235,7 +235,7 @@ export const ExpressiveSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -246,7 +246,7 @@ export const FidelitySt: Story = {
     scheme: "fidelity",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -261,7 +261,7 @@ export const FidelitySt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -272,7 +272,7 @@ export const ContentSt: Story = {
     scheme: "content",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -287,7 +287,7 @@ export const ContentSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -306,7 +306,7 @@ export const ContrastLowSt: Story = {
     contrast: -1,
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -321,7 +321,7 @@ export const ContrastLowSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -332,7 +332,7 @@ export const ContrastMediumSt: Story = {
     contrast: 0,
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -347,7 +347,7 @@ export const ContrastMediumSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -358,7 +358,7 @@ export const ContrastHighSt: Story = {
     contrast: 1,
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -373,7 +373,7 @@ export const ContrastHighSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -392,7 +392,7 @@ export const PrimarySt: Story = {
     primary: "#cab337",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -407,7 +407,7 @@ export const PrimarySt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -421,7 +421,7 @@ export const PrimarySecondarySt: Story = {
     secondary: "#b03a3a",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -436,7 +436,7 @@ export const PrimarySecondarySt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -451,7 +451,7 @@ export const PrimarySecondaryTertiarySt: Story = {
     tertiary: "#2138d2",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -466,7 +466,7 @@ export const PrimarySecondaryTertiarySt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -482,7 +482,7 @@ export const PrimarySecondaryTertiaryErrorSt: Story = {
     error: "#479200",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -497,7 +497,7 @@ export const PrimarySecondaryTertiaryErrorSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -514,7 +514,7 @@ export const PrimarySecondaryTertiaryErrorNeutralSt: Story = {
     neutral: "#957FF1",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -529,7 +529,7 @@ export const PrimarySecondaryTertiaryErrorNeutralSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -547,7 +547,7 @@ export const PrimarySecondaryTertiaryErrorNeutralNeutralVariantSt: Story = {
     neutralVariant: "#007EDF",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Layout>
         <Scheme
           theme="light"
@@ -562,7 +562,7 @@ export const PrimarySecondaryTertiaryErrorNeutralNeutralVariantSt: Story = {
         />
         <Shades customColors={args.customColors} />
       </Layout>
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -582,9 +582,9 @@ export const PrimarySecondaryTertiaryErrorNeutralNeutralVariantSt: Story = {
 //       colorMatch: true,
 //     },
 //     render: (args) => (
-//       <Mcu {...args}>
+//       <Mtb {...args}>
 //         <Bar customColors={args.customColors} />
-//       </Mcu>
+//       </Mtb>
 //     ),
 //   };
 
@@ -632,9 +632,9 @@ export const TailwindSt: Story = {
   name: "Tailwind",
   args: CustomColorsSt.args,
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <TailwindScheme />
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -730,7 +730,7 @@ export const RecolorizeSvgSt1: Story = {
     source: "#769CDF",
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Scene
         customColors={args.customColors}
         // includedPalettesNames={[
@@ -740,7 +740,7 @@ export const RecolorizeSvgSt1: Story = {
         // ]}
         excludedPalettesNames={["error"]}
       />
-    </Mcu>
+    </Mtb>
   ),
 };
 
@@ -762,7 +762,7 @@ export const RecolorizeSvgSt2: Story = {
     ],
   },
   render: (args) => (
-    <Mcu {...args}>
+    <Mtb {...args}>
       <Scene
         customColors={args.customColors}
         // includedPalettesNames={[
@@ -772,6 +772,6 @@ export const RecolorizeSvgSt2: Story = {
         // ]}
         excludedPalettesNames={["error"]}
       />
-    </Mcu>
+    </Mtb>
   ),
 };

--- a/src/Mtb.test.tsx
+++ b/src/Mtb.test.tsx
@@ -1,9 +1,9 @@
 import { cleanup, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it } from "vitest";
-import { Mcu } from "./Mcu";
+import { Mcu, Mtb } from "./Mtb";
 
-describe("Mcu", () => {
+describe("Mtb", () => {
   afterEach(() => {
     cleanup();
     // Also manually remove any leftover style tags
@@ -12,9 +12,9 @@ describe("Mcu", () => {
 
   it("should inject style tag with --md-sys-color-* CSS variables", () => {
     render(
-      <Mcu source="#6750A4" scheme="tonalSpot" contrast={0} customColors={[]}>
+      <Mtb source="#6750A4" scheme="tonalSpot" contrast={0} customColors={[]}>
         <div>Test content</div>
-      </Mcu>,
+      </Mtb>,
     );
 
     // Check that the style tag exists
@@ -33,7 +33,7 @@ describe("Mcu", () => {
   it("should remove custom color CSS variables when customColors are removed", () => {
     // First render with custom colors
     const { rerender } = render(
-      <Mcu
+      <Mtb
         source="#6750A4"
         customColors={[
           { name: "brand", hex: "#FF5733", blend: true },
@@ -41,7 +41,7 @@ describe("Mcu", () => {
         ]}
       >
         <div>Test content</div>
-      </Mcu>,
+      </Mtb>,
     );
 
     // Check that custom color variables are present
@@ -53,12 +53,12 @@ describe("Mcu", () => {
 
     // Rerender with only one custom color (removing "success")
     rerender(
-      <Mcu
+      <Mtb
         source="#6750A4"
         customColors={[{ name: "brand", hex: "#FF5733", blend: true }]}
       >
         <div>Test content</div>
-      </Mcu>,
+      </Mtb>,
     );
 
     // Check that "success" variables are removed
@@ -73,9 +73,9 @@ describe("Mcu", () => {
 
     // Rerender with no custom colors (empty array)
     rerender(
-      <Mcu source="#6750A4" customColors={[]}>
+      <Mtb source="#6750A4" customColors={[]}>
         <div>Test content</div>
-      </Mcu>,
+      </Mtb>,
     );
 
     // Check that all custom color variables are removed
@@ -86,9 +86,9 @@ describe("Mcu", () => {
 
     // Rerender without customColors prop at all (should use default empty array)
     rerender(
-      <Mcu source="#6750A4">
+      <Mtb source="#6750A4">
         <div>Test content</div>
-      </Mcu>,
+      </Mtb>,
     );
 
     // Check that custom colors are still not present
@@ -104,9 +104,9 @@ describe("Mcu", () => {
     // used to reach the browser with no colors at all and paint an unthemed
     // first frame.
     const html = renderToStaticMarkup(
-      <Mcu source="#6750A4">
+      <Mtb source="#6750A4">
         <div>Test content</div>
-      </Mcu>,
+      </Mtb>,
     );
 
     const open = '<style id="mcu-styles">';
@@ -126,5 +126,9 @@ describe("Mcu", () => {
     // escapes text children, which would turn a `&` or `>` in a selector into
     // an entity and break the sheet.
     expect(css).not.toMatch(/&(amp|gt|lt|quot|#x27);/);
+  });
+
+  it("should keep `Mcu` as a deprecated alias of `Mtb`", () => {
+    expect(Mcu).toBe(Mtb);
   });
 });

--- a/src/Mtb.tsx
+++ b/src/Mtb.tsx
@@ -16,7 +16,7 @@ const DEFAULT_COLOR_MATCH = false;
 /**
  * Root component that generates and injects a Material You color theme into the page.
  */
-export function Mcu({
+export function Mtb({
   source,
   scheme = DEFAULT_SCHEME,
   contrast = DEFAULT_CONTRAST,
@@ -71,3 +71,9 @@ export function Mcu({
     </McuProvider>
   );
 }
+
+/**
+ * @deprecated Renamed `Mtb` — same component, same props. This alias will be
+ * removed in the next major.
+ */
+export const Mcu = Mtb;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
 // server and client graphs registers every export of a `"use client"` module
 // it sees, including through a re-export. While this file re-exported them,
 // `import { builder } from "material-theme-builder"` in a server component
-// still shipped `Mcu` and the color utilities to the browser, for a component
+// still shipped `Mtb` and the color utilities to the browser, for a component
 // the page never rendered.
 
 export { builder } from "./lib/builder";

--- a/src/react.ts
+++ b/src/react.ts
@@ -4,5 +4,5 @@
 // callable from a server component. See tsup.config.ts.
 
 export { ExportButton } from "./ExportButton";
-export { Mcu } from "./Mcu";
 export { useMcu } from "./Mcu.context";
+export { Mcu, Mtb } from "./Mtb";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "tsup";
 // React surface -- and so that nothing on the root entry points at it:
 //
 //   dist/index.js   no directive -- `builder`, the package root
-//   dist/react.js   "use client" -- Mcu, useMcu, ExportButton
+//   dist/react.js   "use client" -- Mtb, useMcu, ExportButton
 //   dist/cli.js     the CLI
 //
 // The two are independent: `index.js` does not import `react.js`, which is


### PR DESCRIPTION
The React root component is now `Mtb` (after the package name, material-theme-builder). `Mcu` keeps working as a deprecated alias of `Mtb` — same component, same props — flagged `@deprecated` so editors strike it through; it will be removed in the next major.

- `src/Mcu.tsx` → `src/Mtb.tsx` (stories, helpers and tests renamed along)
- `material-theme-builder/react` now exports both `Mtb` and the deprecated `Mcu`
- `useMcu` / `McuConfig` / `McuProvider` are untouched (out of scope here)
- changeset: minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ftmSFU2FTtvo5JSzXvXSn