### PR TITLE
feat: add a Tailwind 4 plugin (@plugin "material-theme-builder/tailwind")

### DIFF
--- a/.changeset/tailwind-plugin.md
+++ b/.changeset/tailwind-plugin.md
@@ -14,9 +14,7 @@ included:
 }
 ```
 
-Options: `custom-colors` (names), `config` (path to a JSON file with a
-`customColors` array, shareable with `<Mtb>` for a single source of truth),
-`prefix` (default `md`).
+Options: `custom-colors` (names), `prefix` (default `md`).
 
 The static `material-theme-builder/tailwind.css` fallback is now generated from
 `toTailwind()`: it gains the missing `--color-surface-tint` /

--- a/.changeset/tailwind-plugin.md
+++ b/.changeset/tailwind-plugin.md
@@ -1,0 +1,24 @@
+---
+"material-theme-builder": minor
+---
+
+feat: add a Tailwind 4 plugin — `@plugin "material-theme-builder/tailwind"`
+
+One line replaces the whole manual `@theme inline` block, custom colors
+included:
+
+```css
+@import "tailwindcss";
+@plugin "material-theme-builder/tailwind" {
+  custom-colors: myCustomColor1, myCustomColor2;
+}
+```
+
+Options: `custom-colors` (names), `config` (path to a JSON file with a
+`customColors` array, shareable with `<Mtb>` for a single source of truth),
+`prefix` (default `md`).
+
+The static `material-theme-builder/tailwind.css` fallback is now generated from
+`toTailwind()`: it gains the missing `--color-surface-tint` /
+`--color-surface-variant` mappings and no longer ships the `myCustomColor1` /
+`myCustomColor2` placeholder entries.

--- a/README.md
+++ b/README.md
@@ -151,32 +151,8 @@ build time: list their names —
 — which yields `bg-my-custom-color-1`, `text-on-my-custom-color-1`,
 `bg-my-custom-color-1-container`, shades `bg-my-custom-color-1-50`…`950`, etc.
 
-Or avoid the duplication entirely by sharing one JSON file with `<Mtb>`:
-
-```jsonc
-// mtb.json
-{
-  "customColors": [
-    { "name": "myCustomColor1", "hex": "#FFDE3F", "blend": true },
-  ],
-}
-```
-
-```css
-@plugin "material-theme-builder/tailwind" {
-  config: "./mtb.json"; /* resolved from the cwd, usually the project root */
-}
-```
-
-```tsx
-import mtb from "./mtb.json";
-
-<Mtb source="#4285F4" customColors={mtb.customColors}>
-```
-
-Options: `custom-colors` (name or comma-separated names), `config` (path to a
-JSON file with a `customColors` array), `prefix` (default `md` — must match the
-`prefix` prop/option).
+Options: `custom-colors` (name or comma-separated names), `prefix` (default
+`md` — must match the `prefix` prop/option).
 
 <details>
 <summary>Without the plugin (manual theme variables)</summary>

--- a/README.md
+++ b/README.md
@@ -127,247 +127,101 @@ return (
 
 ## Tailwind
 
-Compatible through [theme variables](https://tailwindcss.com/docs/theme):
+A [Tailwind 4 plugin](https://tailwindcss.com/docs/functions-and-directives#plugin-directive) maps every Material token to a [theme variable](https://tailwindcss.com/docs/theme):
 
 ```css
-@theme inline {
-  --color-background: var(--md-sys-color-background);
-  --color-on-background: var(--md-sys-color-on-background);
-  --color-surface: var(--md-sys-color-surface);
-  --color-surface-dim: var(--md-sys-color-surface-dim);
-  --color-surface-bright: var(--md-sys-color-surface-bright);
-  --color-surface-container-lowest: var(
-    --md-sys-color-surface-container-lowest
-  );
-  --color-surface-container-low: var(--md-sys-color-surface-container-low);
-  --color-surface-container: var(--md-sys-color-surface-container);
-  --color-surface-container-high: var(--md-sys-color-surface-container-high);
-  --color-surface-container-highest: var(
-    --md-sys-color-surface-container-highest
-  );
-  --color-on-surface: var(--md-sys-color-on-surface);
-  --color-on-surface-variant: var(--md-sys-color-on-surface-variant);
-  --color-outline: var(--md-sys-color-outline);
-  --color-outline-variant: var(--md-sys-color-outline-variant);
-  --color-inverse-surface: var(--md-sys-color-inverse-surface);
-  --color-inverse-on-surface: var(--md-sys-color-inverse-on-surface);
-  --color-primary: var(--md-sys-color-primary);
-  --color-on-primary: var(--md-sys-color-on-primary);
-  --color-primary-container: var(--md-sys-color-primary-container);
-  --color-on-primary-container: var(--md-sys-color-on-primary-container);
-  --color-primary-fixed: var(--md-sys-color-primary-fixed);
-  --color-primary-fixed-dim: var(--md-sys-color-primary-fixed-dim);
-  --color-on-primary-fixed: var(--md-sys-color-on-primary-fixed);
-  --color-on-primary-fixed-variant: var(
-    --md-sys-color-on-primary-fixed-variant
-  );
-  --color-inverse-primary: var(--md-sys-color-inverse-primary);
-  --color-secondary: var(--md-sys-color-secondary);
-  --color-on-secondary: var(--md-sys-color-on-secondary);
-  --color-secondary-container: var(--md-sys-color-secondary-container);
-  --color-on-secondary-container: var(--md-sys-color-on-secondary-container);
-  --color-secondary-fixed: var(--md-sys-color-secondary-fixed);
-  --color-secondary-fixed-dim: var(--md-sys-color-secondary-fixed-dim);
-  --color-on-secondary-fixed: var(--md-sys-color-on-secondary-fixed);
-  --color-on-secondary-fixed-variant: var(
-    --md-sys-color-on-secondary-fixed-variant
-  );
-  --color-tertiary: var(--md-sys-color-tertiary);
-  --color-on-tertiary: var(--md-sys-color-on-tertiary);
-  --color-tertiary-container: var(--md-sys-color-tertiary-container);
-  --color-on-tertiary-container: var(--md-sys-color-on-tertiary-container);
-  --color-tertiary-fixed: var(--md-sys-color-tertiary-fixed);
-  --color-tertiary-fixed-dim: var(--md-sys-color-tertiary-fixed-dim);
-  --color-on-tertiary-fixed: var(--md-sys-color-on-tertiary-fixed);
-  --color-on-tertiary-fixed-variant: var(
-    --md-sys-color-on-tertiary-fixed-variant
-  );
-  --color-error: var(--md-sys-color-error);
-  --color-on-error: var(--md-sys-color-on-error);
-  --color-error-container: var(--md-sys-color-error-container);
-  --color-on-error-container: var(--md-sys-color-on-error-container);
-  --color-scrim: var(--md-sys-color-scrim);
-  --color-shadow: var(--md-sys-color-shadow);
+@import "tailwindcss";
+@plugin "material-theme-builder/tailwind";
+```
 
-  /* Shades */
+You get `bg-primary`, `text-on-surface`, `border-outline-variant`, shades like
+`bg-primary-100` (Tailwind shade → M3 tone: `50`→`95` … `500`→`50` … `950`→`5`),
+all backed by the `--md-sys-color-*` / `--md-ref-palette-*` variables `<Mtb>`
+(or `toCss()`) injects — so they follow scheme/contrast changes live.
 
-  --color-primary-50: var(--md-ref-palette-primary-95);
-  --color-primary-100: var(--md-ref-palette-primary-90);
-  --color-primary-200: var(--md-ref-palette-primary-80);
-  --color-primary-300: var(--md-ref-palette-primary-70);
-  --color-primary-400: var(--md-ref-palette-primary-60);
-  --color-primary-500: var(--md-ref-palette-primary-50);
-  --color-primary-600: var(--md-ref-palette-primary-40);
-  --color-primary-700: var(--md-ref-palette-primary-30);
-  --color-primary-800: var(--md-ref-palette-primary-20);
-  --color-primary-900: var(--md-ref-palette-primary-10);
-  --color-primary-950: var(--md-ref-palette-primary-5);
+Custom colors live in your JS at runtime, so the plugin cannot discover them at
+build time: list their names —
 
-  --color-secondary-50: var(--md-ref-palette-secondary-95);
-  --color-secondary-100: var(--md-ref-palette-secondary-90);
-  --color-secondary-200: var(--md-ref-palette-secondary-80);
-  --color-secondary-300: var(--md-ref-palette-secondary-70);
-  --color-secondary-400: var(--md-ref-palette-secondary-60);
-  --color-secondary-500: var(--md-ref-palette-secondary-50);
-  --color-secondary-600: var(--md-ref-palette-secondary-40);
-  --color-secondary-700: var(--md-ref-palette-secondary-30);
-  --color-secondary-800: var(--md-ref-palette-secondary-20);
-  --color-secondary-900: var(--md-ref-palette-secondary-10);
-  --color-secondary-950: var(--md-ref-palette-secondary-5);
-
-  --color-tertiary-50: var(--md-ref-palette-tertiary-95);
-  --color-tertiary-100: var(--md-ref-palette-tertiary-90);
-  --color-tertiary-200: var(--md-ref-palette-tertiary-80);
-  --color-tertiary-300: var(--md-ref-palette-tertiary-70);
-  --color-tertiary-400: var(--md-ref-palette-tertiary-60);
-  --color-tertiary-500: var(--md-ref-palette-tertiary-50);
-  --color-tertiary-600: var(--md-ref-palette-tertiary-40);
-  --color-tertiary-700: var(--md-ref-palette-tertiary-30);
-  --color-tertiary-800: var(--md-ref-palette-tertiary-20);
-  --color-tertiary-900: var(--md-ref-palette-tertiary-10);
-  --color-tertiary-950: var(--md-ref-palette-tertiary-5);
-
-  --color-error-50: var(--md-ref-palette-error-95);
-  --color-error-100: var(--md-ref-palette-error-90);
-  --color-error-200: var(--md-ref-palette-error-80);
-  --color-error-300: var(--md-ref-palette-error-70);
-  --color-error-400: var(--md-ref-palette-error-60);
-  --color-error-500: var(--md-ref-palette-error-50);
-  --color-error-600: var(--md-ref-palette-error-40);
-  --color-error-700: var(--md-ref-palette-error-30);
-  --color-error-800: var(--md-ref-palette-error-20);
-  --color-error-900: var(--md-ref-palette-error-10);
-  --color-error-950: var(--md-ref-palette-error-5);
-
-  --color-neutral-50: var(--md-ref-palette-neutral-95);
-  --color-neutral-100: var(--md-ref-palette-neutral-90);
-  --color-neutral-200: var(--md-ref-palette-neutral-80);
-  --color-neutral-300: var(--md-ref-palette-neutral-70);
-  --color-neutral-400: var(--md-ref-palette-neutral-60);
-  --color-neutral-500: var(--md-ref-palette-neutral-50);
-  --color-neutral-600: var(--md-ref-palette-neutral-40);
-  --color-neutral-700: var(--md-ref-palette-neutral-30);
-  --color-neutral-800: var(--md-ref-palette-neutral-20);
-  --color-neutral-900: var(--md-ref-palette-neutral-10);
-  --color-neutral-950: var(--md-ref-palette-neutral-5);
-
-  --color-neutral-variant-50: var(--md-ref-palette-neutral-variant-95);
-  --color-neutral-variant-100: var(--md-ref-palette-neutral-variant-90);
-  --color-neutral-variant-200: var(--md-ref-palette-neutral-variant-80);
-  --color-neutral-variant-300: var(--md-ref-palette-neutral-variant-70);
-  --color-neutral-variant-400: var(--md-ref-palette-neutral-variant-60);
-  --color-neutral-variant-500: var(--md-ref-palette-neutral-variant-50);
-  --color-neutral-variant-600: var(--md-ref-palette-neutral-variant-40);
-  --color-neutral-variant-700: var(--md-ref-palette-neutral-variant-30);
-  --color-neutral-variant-800: var(--md-ref-palette-neutral-variant-20);
-  --color-neutral-variant-900: var(--md-ref-palette-neutral-variant-10);
-  --color-neutral-variant-950: var(--md-ref-palette-neutral-variant-5);
-
-  /*
-   * Custom colors
-   */
-
-  --color-myCustomColor1: var(--md-sys-color-my-custom-color-1);
-  --color-on-myCustomColor1: var(--md-sys-color-on-my-custom-color-1);
-  --color-myCustomColor1-container: var(
-    --md-sys-color-my-custom-color-1-container
-  );
-  --color-on-myCustomColor1-container: var(
-    --md-sys-color-on-my-custom-color-1-container
-  );
-  /* Shades */
-  --color-myCustomColor1-50: var(--md-ref-palette-my-custom-color-1-95);
-  --color-myCustomColor1-100: var(--md-ref-palette-my-custom-color-1-90);
-  --color-myCustomColor1-200: var(--md-ref-palette-my-custom-color-1-80);
-  --color-myCustomColor1-300: var(--md-ref-palette-my-custom-color-1-70);
-  --color-myCustomColor1-400: var(--md-ref-palette-my-custom-color-1-60);
-  --color-myCustomColor1-500: var(--md-ref-palette-my-custom-color-1-50);
-  --color-myCustomColor1-600: var(--md-ref-palette-my-custom-color-1-40);
-  --color-myCustomColor1-700: var(--md-ref-palette-my-custom-color-1-30);
-  --color-myCustomColor1-800: var(--md-ref-palette-my-custom-color-1-20);
-  --color-myCustomColor1-900: var(--md-ref-palette-my-custom-color-1-10);
-  --color-myCustomColor1-950: var(--md-ref-palette-my-custom-color-1-5);
-
-  --color-myCustomColor2: var(--md-sys-color-my-custom-color-2);
-  --color-on-myCustomColor2: var(--md-sys-color-on-my-custom-color-2);
-  --color-myCustomColor2-container: var(
-    --md-sys-color-my-custom-color-2-container
-  );
-  --color-on-myCustomColor2-container: var(
-    --md-sys-color-on-my-custom-color-2-container
-  );
-  /* Shades */
-  --color-myCustomColor2-50: var(--md-ref-palette-my-custom-color-2-95);
-  --color-myCustomColor2-100: var(--md-ref-palette-my-custom-color-2-90);
-  --color-myCustomColor2-200: var(--md-ref-palette-my-custom-color-2-80);
-  --color-myCustomColor2-300: var(--md-ref-palette-my-custom-color-2-70);
-  --color-myCustomColor2-400: var(--md-ref-palette-my-custom-color-2-60);
-  --color-myCustomColor2-500: var(--md-ref-palette-my-custom-color-2-50);
-  --color-myCustomColor2-600: var(--md-ref-palette-my-custom-color-2-40);
-  --color-myCustomColor2-700: var(--md-ref-palette-my-custom-color-2-30);
-  --color-myCustomColor2-800: var(--md-ref-palette-my-custom-color-2-20);
-  --color-myCustomColor2-900: var(--md-ref-palette-my-custom-color-2-10);
-  --color-myCustomColor2-950: var(--md-ref-palette-my-custom-color-2-5);
+```css
+@plugin "material-theme-builder/tailwind" {
+  custom-colors: myCustomColor1, myCustomColor2;
 }
 ```
 
-Or simply:
+— which yields `bg-my-custom-color-1`, `text-on-my-custom-color-1`,
+`bg-my-custom-color-1-container`, shades `bg-my-custom-color-1-50`…`950`, etc.
+
+Or avoid the duplication entirely by sharing one JSON file with `<Mtb>`:
+
+```jsonc
+// mtb.json
+{
+  "customColors": [
+    { "name": "myCustomColor1", "hex": "#FFDE3F", "blend": true },
+  ],
+}
+```
+
+```css
+@plugin "material-theme-builder/tailwind" {
+  config: "./mtb.json"; /* resolved from the cwd, usually the project root */
+}
+```
+
+```tsx
+import mtb from "./mtb.json";
+
+<Mtb source="#4285F4" customColors={mtb.customColors}>
+```
+
+Options: `custom-colors` (name or comma-separated names), `config` (path to a
+JSON file with a `customColors` array), `prefix` (default `md` — must match the
+`prefix` prop/option).
+
+<details>
+<summary>Without the plugin (manual theme variables)</summary>
+
+Standard tokens are covered by a static stylesheet:
 
 ```css
 @import "material-theme-builder/tailwind.css";
 ```
 
-> [!IMPORTANT]
->
-> Do not forget to manually add your custom colors, as in:
->
-> ```css
-> /*
->  * Custom colors
->  */
->
-> --color-myCustomColor1: var(--md-sys-color-my-custom-color-1);
-> --color-on-myCustomColor1: var(--md-sys-color-on-my-custom-color-1);
-> --color-myCustomColor1-container: var(
->   --md-sys-color-my-custom-color-1-container
-> );
-> --color-on-myCustomColor1-container: var(
->   --md-sys-color-on-my-custom-color-1-container
-> );
-> /* Shades */
-> --color-myCustomColor1-50: var(--md-ref-palette-my-custom-color-1-95);
-> --color-myCustomColor1-100: var(--md-ref-palette-my-custom-color-1-90);
-> --color-myCustomColor1-200: var(--md-ref-palette-my-custom-color-1-80);
-> --color-myCustomColor1-300: var(--md-ref-palette-my-custom-color-1-70);
-> --color-myCustomColor1-400: var(--md-ref-palette-my-custom-color-1-60);
-> --color-myCustomColor1-500: var(--md-ref-palette-my-custom-color-1-50);
-> --color-myCustomColor1-600: var(--md-ref-palette-my-custom-color-1-40);
-> --color-myCustomColor1-700: var(--md-ref-palette-my-custom-color-1-30);
-> --color-myCustomColor1-800: var(--md-ref-palette-my-custom-color-1-20);
-> --color-myCustomColor1-900: var(--md-ref-palette-my-custom-color-1-10);
-> --color-myCustomColor1-950: var(--md-ref-palette-my-custom-color-1-5);
->
-> --color-myCustomColor2: var(--md-sys-color-my-custom-color-2);
-> --color-on-myCustomColor2: var(--md-sys-color-on-my-custom-color-2);
-> --color-myCustomColor2-container: var(
->   --md-sys-color-my-custom-color-2-container
-> );
-> --color-on-myCustomColor2-container: var(
->   --md-sys-color-on-my-custom-color-2-container
-> );
-> /* Shades */
-> --color-myCustomColor2-50: var(--md-ref-palette-my-custom-color-2-95);
-> --color-myCustomColor2-100: var(--md-ref-palette-my-custom-color-2-90);
-> --color-myCustomColor2-200: var(--md-ref-palette-my-custom-color-2-80);
-> --color-myCustomColor2-300: var(--md-ref-palette-my-custom-color-2-70);
-> --color-myCustomColor2-400: var(--md-ref-palette-my-custom-color-2-60);
-> --color-myCustomColor2-500: var(--md-ref-palette-my-custom-color-2-50);
-> --color-myCustomColor2-600: var(--md-ref-palette-my-custom-color-2-40);
-> --color-myCustomColor2-700: var(--md-ref-palette-my-custom-color-2-30);
-> --color-myCustomColor2-800: var(--md-ref-palette-my-custom-color-2-20);
-> --color-myCustomColor2-900: var(--md-ref-palette-my-custom-color-2-10);
-> --color-myCustomColor2-950: var(--md-ref-palette-my-custom-color-2-5);
-> ```
+Custom colors must then be mapped by hand, following the same naming scheme —
+for a custom color named `myCustomColor1`:
+
+```css
+@theme inline {
+  --color-my-custom-color-1: var(--md-sys-color-my-custom-color-1);
+  --color-on-my-custom-color-1: var(--md-sys-color-on-my-custom-color-1);
+  --color-my-custom-color-1-container: var(
+    --md-sys-color-my-custom-color-1-container
+  );
+  --color-on-my-custom-color-1-container: var(
+    --md-sys-color-on-my-custom-color-1-container
+  );
+  /* Shades */
+  --color-my-custom-color-1-50: var(--md-ref-palette-my-custom-color-1-95);
+  --color-my-custom-color-1-100: var(--md-ref-palette-my-custom-color-1-90);
+  --color-my-custom-color-1-200: var(--md-ref-palette-my-custom-color-1-80);
+  --color-my-custom-color-1-300: var(--md-ref-palette-my-custom-color-1-70);
+  --color-my-custom-color-1-400: var(--md-ref-palette-my-custom-color-1-60);
+  --color-my-custom-color-1-500: var(--md-ref-palette-my-custom-color-1-50);
+  --color-my-custom-color-1-600: var(--md-ref-palette-my-custom-color-1-40);
+  --color-my-custom-color-1-700: var(--md-ref-palette-my-custom-color-1-30);
+  --color-my-custom-color-1-800: var(--md-ref-palette-my-custom-color-1-20);
+  --color-my-custom-color-1-900: var(--md-ref-palette-my-custom-color-1-10);
+  --color-my-custom-color-1-950: var(--md-ref-palette-my-custom-color-1-5);
+}
+```
+
+You can also generate the whole block (custom colors included) with the CLI:
+
+```sh
+material-theme-builder '#4285F4' --format tailwind --custom-colors '[{"name":"myCustomColor1","hex":"#FFDE3F","blend":true}]'
+```
+
+</details>
 
 ## shadcn
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/react.d.ts",
       "import": "./dist/react.js"
     },
+    "./tailwind": {
+      "types": "./dist/tailwind-plugin.d.ts",
+      "import": "./dist/tailwind-plugin.js"
+    },
     "./tailwind.css": "./dist/tailwind.css"
   },
   "homepage": "https://github.com/abernier/material-theme-builder",
@@ -53,6 +57,7 @@
     "@types/culori": "^4.0.1",
     "@types/d3": "^7.4.3",
     "@types/lodash-es": "^4.17.12",
+    "@types/node": "^26.1.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/seedrandom": "^3.0.8",
@@ -116,7 +121,13 @@
   },
   "peerDependencies": {
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "tailwindcss": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@material/material-color-utilities": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@types/culori": "^4.0.1",
     "@types/d3": "^7.4.3",
     "@types/lodash-es": "^4.17.12",
-    "@types/node": "^26.1.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/seedrandom": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
-      '@types/node':
-        specifier: ^26.1.2
-        version: 26.1.2
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.14
@@ -7545,6 +7542,7 @@ snapshots:
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
+    optional: true
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -10192,7 +10190,8 @@ snapshots:
 
   ufo@1.6.2: {}
 
-  undici-types@8.3.0: {}
+  undici-types@8.3.0:
+    optional: true
 
   undici@7.22.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 0.18.2
       '@changesets/cli':
         specifier: ^2.27.7
-        version: 2.29.8(@types/node@25.3.3)
+        version: 2.29.8(@types/node@26.1.2)
       '@chromatic-com/storybook':
         specifier: ^5.0.0
         version: 5.0.1(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -41,13 +41,13 @@ importers:
         version: 1.123.0
       '@storybook/addon-docs':
         specifier: ^10.1.11
-        version: 10.2.12(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.12(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/addon-themes':
         specifier: ^10.1.11
         version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/react-vite':
         specifier: ^10.1.11
-        version: 10.2.12(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.12(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.2.1
@@ -66,6 +66,9 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
+      '@types/node':
+        specifier: ^26.1.2
+        version: 26.1.2
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.14
@@ -77,7 +80,7 @@ importers:
         version: 3.0.8
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -149,7 +152,7 @@ importers:
         version: 3.0.5
       shadcn:
         specifier: ^3.8.5
-        version: 3.8.5(@types/node@25.3.3)(typescript@5.9.3)
+        version: 3.8.5(@types/node@26.1.2)(typescript@5.9.3)
       simplex-noise:
         specifier: ^4.0.3
         version: 4.0.3
@@ -179,16 +182,16 @@ importers:
         version: 3.1.1(react@19.2.4)
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       vite-plugin-singlefile:
         specifier: 2.3.0
-        version: 2.3.0(rollup@4.57.1)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.3.0(rollup@4.57.1)(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.16
-        version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@26.1.2)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@26.1.2)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -2425,8 +2428,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.3.3':
-    resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -4961,8 +4964,8 @@ packages:
   ufo@1.6.2:
     resolution: {integrity: sha512-heMioaxBcG9+Znsda5Q8sQbWnLJSl98AFDXTO80wELWEzX3hordXsTdxrIfMQoO9IY1MEnoGoPjpoKpMj+Yx0Q==}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
@@ -5674,7 +5677,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.8(@types/node@25.3.3)':
+  '@changesets/cli@2.29.8(@types/node@26.1.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -5690,7 +5693,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.3.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.1.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -6082,44 +6085,44 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/confirm@5.1.21(@types/node@25.3.3)':
+  '@inquirer/confirm@5.1.21(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@26.1.2)
+      '@inquirer/type': 3.0.10(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 26.1.2
 
-  '@inquirer/core@10.3.2(@types/node@25.3.3)':
+  '@inquirer/core@10.3.2(@types/node@26.1.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/type': 3.0.10(@types/node@26.1.2)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 26.1.2
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.3.3)':
+  '@inquirer/external-editor@1.0.3(@types/node@26.1.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.1
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 26.1.2
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/type@3.0.10(@types/node@25.3.3)':
+  '@inquirer/type@3.0.10(@types/node@26.1.2)':
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 26.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -7171,10 +7174,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.2.12(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/addon-docs@10.2.12(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -7193,25 +7196,25 @@ snapshots:
       storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/builder-vite@10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/csf-plugin@10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
       rollup: 4.57.1
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@storybook/global@5.0.0': {}
 
@@ -7226,11 +7229,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.2.12(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/react-vite@10.2.12(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/builder-vite': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/react': 10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -7240,7 +7243,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -7539,10 +7542,9 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.3.3':
+  '@types/node@26.1.2':
     dependencies:
-      undici-types: 7.18.2
-    optional: true
+      undici-types: 8.3.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -7651,7 +7653,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -7659,7 +7661,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7680,14 +7682,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@26.1.2)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.10(@types/node@25.3.3)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      msw: 2.12.10(@types/node@26.1.2)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9184,9 +9186,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3):
+  msw@2.12.10(@types/node@26.1.2)(typescript@5.9.3):
     dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@25.3.3)
+      '@inquirer/confirm': 5.1.21(@types/node@26.1.2)
       '@mswjs/interceptors': 0.41.3
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
@@ -9810,7 +9812,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.8.5(@types/node@25.3.3)(typescript@5.9.3):
+  shadcn@3.8.5(@types/node@26.1.2)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.29.0
@@ -9832,7 +9834,7 @@ snapshots:
       fuzzysort: 3.1.0
       https-proxy-agent: 7.0.6
       kleur: 4.1.5
-      msw: 2.12.10(@types/node@25.3.3)(typescript@5.9.3)
+      msw: 2.12.10(@types/node@26.1.2)(typescript@5.9.3)
       node-fetch: 3.3.2
       open: 11.0.0
       ora: 8.2.0
@@ -10190,8 +10192,7 @@ snapshots:
 
   ufo@1.6.2: {}
 
-  undici-types@7.18.2:
-    optional: true
+  undici-types@8.3.0: {}
 
   undici@7.22.0: {}
 
@@ -10256,23 +10257,23 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-singlefile@2.3.0(rollup@4.57.1)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-singlefile@2.3.0(rollup@4.57.1)(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       micromatch: 4.0.8
       rollup: 4.57.1
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -10281,17 +10282,17 @@ snapshots:
       rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 26.1.2
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@26.1.2)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@26.1.2)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@26.1.2)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -10308,10 +10309,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 26.1.2
       jsdom: 28.1.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti

--- a/src/lib/builder.tailwind.ts
+++ b/src/lib/builder.tailwind.ts
@@ -1,6 +1,6 @@
-import { kebabCase } from "lodash-es";
+import { kebabCase, upperFirst } from "lodash-es";
 
-import type { BuilderContext } from "./builder";
+import { type BuilderContext, tokenNames } from "./builder";
 import { SHADCN_MAPPING } from "./builder.shadcn";
 
 // Tailwind shade → M3 tone mapping
@@ -27,6 +27,52 @@ const CORE_PALETTES = [
   "neutral",
   "neutral-variant",
 ] as const;
+
+/**
+ * The four scheme token names generated for a custom color — the same names
+ * mergeBaseAndCustomColors() produces in builder.ts.
+ */
+function customColorTokenNames(name: string) {
+  return [
+    name,
+    `on${upperFirst(name)}`,
+    `${name}Container`,
+    `on${upperFirst(name)}Container`,
+  ];
+}
+
+/**
+ * Flat Tailwind `colors` record (utility name → `var()` reference) — the JS
+ * equivalent of the `@theme inline` block emitted by buildTailwind(), for the
+ * Tailwind plugin (tailwind-plugin.ts) where custom colors are only known by
+ * name, not by value.
+ */
+export function tailwindThemeColors(
+  prefix: string,
+  customColorNames: string[] = [],
+) {
+  const colors: Record<string, string> = {};
+
+  for (const token of [
+    ...tokenNames,
+    ...customColorNames.flatMap(customColorTokenNames),
+  ]) {
+    const kebab = kebabCase(token);
+    colors[kebab] = `var(--${prefix}-sys-color-${kebab})`;
+  }
+
+  for (const palette of [
+    ...CORE_PALETTES,
+    ...customColorNames.map(kebabCase),
+  ]) {
+    for (const [shade, tone] of SHADE_TO_TONE) {
+      colors[`${palette}-${shade}`] =
+        `var(--${prefix}-ref-palette-${palette}-${tone})`;
+    }
+  }
+
+  return colors;
+}
 
 /** Options for the Tailwind CSS exporter. */
 export type TailwindOptions = {

--- a/src/tailwind-plugin.test.ts
+++ b/src/tailwind-plugin.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { builder } from "./lib/builder";
+import mtbPlugin, {
+  type MaterialThemeBuilderPluginOptions,
+} from "./tailwind-plugin";
+
+// Colors the plugin registers for the given `@plugin` options
+function pluginColors(options?: MaterialThemeBuilderPluginOptions) {
+  const config = mtbPlugin(options).config;
+  return config?.theme?.extend?.colors as Record<string, string>;
+}
+
+// `--color-X: var(--Y);` pairs of a `@theme inline` CSS block
+function themeBlockColors(css: string) {
+  const declarations = css
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\s+/g, " ")
+    .matchAll(/--color-([\w-]+): var\( ?(--[\w-]+) ?\);/g);
+  return Object.fromEntries(
+    [...declarations].map(([, name, varname]) => [name, `var(${varname})`]),
+  );
+}
+
+describe("tailwind plugin", () => {
+  it("should map standard tokens and shades", () => {
+    const colors = pluginColors();
+    expect(colors["primary"]).toBe("var(--md-sys-color-primary)");
+    expect(colors["on-surface-variant"]).toBe(
+      "var(--md-sys-color-on-surface-variant)",
+    );
+    expect(colors["primary-500"]).toBe("var(--md-ref-palette-primary-50)");
+    expect(colors["neutral-variant-950"]).toBe(
+      "var(--md-ref-palette-neutral-variant-5)",
+    );
+  });
+
+  it("should match the static tailwind.css fallback", () => {
+    const css = readFileSync(join(import.meta.dirname, "tailwind.css"), "utf8");
+    expect(pluginColors()).toEqual(themeBlockColors(css));
+  });
+
+  it("should match toTailwind() output, custom colors included", () => {
+    const css = builder("#6750A4", {
+      customColors: [{ name: "myCustomColor1", hex: "#FF5733", blend: true }],
+    }).toTailwind();
+    expect(pluginColors({ "custom-colors": "myCustomColor1" })).toEqual(
+      themeBlockColors(css),
+    );
+  });
+
+  it("should accept a list of custom colors", () => {
+    const colors = pluginColors({
+      "custom-colors": ["myCustomColor1", "myCustomColor2"],
+    });
+    expect(colors["my-custom-color-1"]).toBe(
+      "var(--md-sys-color-my-custom-color-1)",
+    );
+    expect(colors["on-my-custom-color-1-container"]).toBe(
+      "var(--md-sys-color-on-my-custom-color-1-container)",
+    );
+    expect(colors["my-custom-color-2-300"]).toBe(
+      "var(--md-ref-palette-my-custom-color-2-70)",
+    );
+  });
+
+  it("should respect the prefix option", () => {
+    const colors = pluginColors({ prefix: "my" });
+    expect(colors["primary"]).toBe("var(--my-sys-color-primary)");
+    expect(colors["primary-500"]).toBe("var(--my-ref-palette-primary-50)");
+  });
+
+  it("should read custom color names from a config file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mtb-"));
+    const file = join(dir, "mtb.json");
+    writeFileSync(
+      file,
+      JSON.stringify({
+        customColors: [
+          { name: "myCustomColor1", hex: "#FF5733", blend: true },
+          { name: "myCustomColor2", hex: "#33FF57", blend: false },
+        ],
+      }),
+    );
+
+    const colors = pluginColors({
+      config: file,
+      "custom-colors": "myCustomColor1",
+    });
+    expect(colors["my-custom-color-1"]).toBe(
+      "var(--md-sys-color-my-custom-color-1)",
+    );
+    expect(colors["my-custom-color-2"]).toBe(
+      "var(--md-sys-color-my-custom-color-2)",
+    );
+  });
+});

--- a/src/tailwind-plugin.test.ts
+++ b/src/tailwind-plugin.test.ts
@@ -1,5 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -72,30 +71,5 @@ describe("tailwind plugin", () => {
     const colors = pluginColors({ prefix: "my" });
     expect(colors["primary"]).toBe("var(--my-sys-color-primary)");
     expect(colors["primary-500"]).toBe("var(--my-ref-palette-primary-50)");
-  });
-
-  it("should read custom color names from a config file", () => {
-    const dir = mkdtempSync(join(tmpdir(), "mtb-"));
-    const file = join(dir, "mtb.json");
-    writeFileSync(
-      file,
-      JSON.stringify({
-        customColors: [
-          { name: "myCustomColor1", hex: "#FF5733", blend: true },
-          { name: "myCustomColor2", hex: "#33FF57", blend: false },
-        ],
-      }),
-    );
-
-    const colors = pluginColors({
-      config: file,
-      "custom-colors": "myCustomColor1",
-    });
-    expect(colors["my-custom-color-1"]).toBe(
-      "var(--md-sys-color-my-custom-color-1)",
-    );
-    expect(colors["my-custom-color-2"]).toBe(
-      "var(--md-sys-color-my-custom-color-2)",
-    );
   });
 });

--- a/src/tailwind-plugin.ts
+++ b/src/tailwind-plugin.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import plugin from "tailwindcss/plugin";
+import { z } from "zod";
+
+import { DEFAULT_PREFIX } from "./lib/builder";
+import { tailwindThemeColors } from "./lib/builder.tailwind";
+
+/**
+ * Options for `@plugin "material-theme-builder/tailwind"`.
+ *
+ * Tailwind parses the `@plugin` option block itself: comma-separated values
+ * arrive as arrays, single values as scalars.
+ */
+export type MaterialThemeBuilderPluginOptions = {
+  /**
+   * Custom color name(s), as passed to `builder()` / `<Mtb customColors>`,
+   * e.g. `custom-colors: myCustomColor1, myCustomColor2;`
+   */
+  "custom-colors"?: string | string[];
+  /**
+   * Path to a JSON file declaring `{ "customColors": [{ "name": … }] }` —
+   * share it with your `<Mtb>` props for a single source of truth. Resolved
+   * from the current working directory (usually the project root).
+   */
+  config?: string;
+  /** CSS variable prefix, matching the `prefix` config (default `md`). */
+  prefix?: string;
+};
+
+const configFileSchema = z.object({
+  customColors: z.array(z.object({ name: z.string() })).default([]),
+});
+
+function customColorNames(options: MaterialThemeBuilderPluginOptions) {
+  const listed = options["custom-colors"] ?? [];
+  const names = Array.isArray(listed) ? [...listed] : [listed];
+
+  if (options.config) {
+    const file = readFileSync(resolve(options.config), "utf8");
+    const parsed = configFileSchema.parse(JSON.parse(file));
+    names.push(...parsed.customColors.map((color) => color.name));
+  }
+
+  return [...new Set(names)];
+}
+
+/**
+ * Tailwind 4 plugin mapping every Material token — including custom colors —
+ * to a Tailwind color, backed by the `--{prefix}-sys-color-*` and
+ * `--{prefix}-ref-palette-*` custom properties that `<Mtb>`/`toCss()` inject.
+ *
+ * ```css
+ * @import "tailwindcss";
+ * @plugin "material-theme-builder/tailwind" {
+ *   custom-colors: myCustomColor1, myCustomColor2;
+ * }
+ * ```
+ */
+export default plugin.withOptions<MaterialThemeBuilderPluginOptions>(
+  () => () => {},
+  (options = {}) => ({
+    theme: {
+      extend: {
+        colors: tailwindThemeColors(
+          options.prefix ?? DEFAULT_PREFIX,
+          customColorNames(options),
+        ),
+      },
+    },
+  }),
+);

--- a/src/tailwind-plugin.ts
+++ b/src/tailwind-plugin.ts
@@ -1,8 +1,4 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
-
 import plugin from "tailwindcss/plugin";
-import { z } from "zod";
 
 import { DEFAULT_PREFIX } from "./lib/builder";
 import { tailwindThemeColors } from "./lib/builder.tailwind";
@@ -19,31 +15,13 @@ export type MaterialThemeBuilderPluginOptions = {
    * e.g. `custom-colors: myCustomColor1, myCustomColor2;`
    */
   "custom-colors"?: string | string[];
-  /**
-   * Path to a JSON file declaring `{ "customColors": [{ "name": … }] }` —
-   * share it with your `<Mtb>` props for a single source of truth. Resolved
-   * from the current working directory (usually the project root).
-   */
-  config?: string;
   /** CSS variable prefix, matching the `prefix` config (default `md`). */
   prefix?: string;
 };
 
-const configFileSchema = z.object({
-  customColors: z.array(z.object({ name: z.string() })).default([]),
-});
-
 function customColorNames(options: MaterialThemeBuilderPluginOptions) {
   const listed = options["custom-colors"] ?? [];
-  const names = Array.isArray(listed) ? [...listed] : [listed];
-
-  if (options.config) {
-    const file = readFileSync(resolve(options.config), "utf8");
-    const parsed = configFileSchema.parse(JSON.parse(file));
-    names.push(...parsed.customColors.map((color) => color.name));
-  }
-
-  return [...new Set(names)];
+  return Array.isArray(listed) ? listed : [listed];
 }
 
 /**

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,61 +1,63 @@
 @theme inline {
   --color-background: var(--md-sys-color-background);
+  --color-error: var(--md-sys-color-error);
+  --color-error-container: var(--md-sys-color-error-container);
+  --color-inverse-on-surface: var(--md-sys-color-inverse-on-surface);
+  --color-inverse-primary: var(--md-sys-color-inverse-primary);
+  --color-inverse-surface: var(--md-sys-color-inverse-surface);
   --color-on-background: var(--md-sys-color-on-background);
-  --color-surface: var(--md-sys-color-surface);
-  --color-surface-dim: var(--md-sys-color-surface-dim);
-  --color-surface-bright: var(--md-sys-color-surface-bright);
-  --color-surface-container-lowest: var(
-    --md-sys-color-surface-container-lowest
+  --color-on-error: var(--md-sys-color-on-error);
+  --color-on-error-container: var(--md-sys-color-on-error-container);
+  --color-on-primary: var(--md-sys-color-on-primary);
+  --color-on-primary-container: var(--md-sys-color-on-primary-container);
+  --color-on-primary-fixed: var(--md-sys-color-on-primary-fixed);
+  --color-on-primary-fixed-variant: var(
+    --md-sys-color-on-primary-fixed-variant
   );
-  --color-surface-container-low: var(--md-sys-color-surface-container-low);
+  --color-on-secondary: var(--md-sys-color-on-secondary);
+  --color-on-secondary-container: var(--md-sys-color-on-secondary-container);
+  --color-on-secondary-fixed: var(--md-sys-color-on-secondary-fixed);
+  --color-on-secondary-fixed-variant: var(
+    --md-sys-color-on-secondary-fixed-variant
+  );
+  --color-on-surface: var(--md-sys-color-on-surface);
+  --color-on-surface-variant: var(--md-sys-color-on-surface-variant);
+  --color-on-tertiary: var(--md-sys-color-on-tertiary);
+  --color-on-tertiary-container: var(--md-sys-color-on-tertiary-container);
+  --color-on-tertiary-fixed: var(--md-sys-color-on-tertiary-fixed);
+  --color-on-tertiary-fixed-variant: var(
+    --md-sys-color-on-tertiary-fixed-variant
+  );
+  --color-outline: var(--md-sys-color-outline);
+  --color-outline-variant: var(--md-sys-color-outline-variant);
+  --color-primary: var(--md-sys-color-primary);
+  --color-primary-container: var(--md-sys-color-primary-container);
+  --color-primary-fixed: var(--md-sys-color-primary-fixed);
+  --color-primary-fixed-dim: var(--md-sys-color-primary-fixed-dim);
+  --color-scrim: var(--md-sys-color-scrim);
+  --color-secondary: var(--md-sys-color-secondary);
+  --color-secondary-container: var(--md-sys-color-secondary-container);
+  --color-secondary-fixed: var(--md-sys-color-secondary-fixed);
+  --color-secondary-fixed-dim: var(--md-sys-color-secondary-fixed-dim);
+  --color-shadow: var(--md-sys-color-shadow);
+  --color-surface: var(--md-sys-color-surface);
+  --color-surface-bright: var(--md-sys-color-surface-bright);
   --color-surface-container: var(--md-sys-color-surface-container);
   --color-surface-container-high: var(--md-sys-color-surface-container-high);
   --color-surface-container-highest: var(
     --md-sys-color-surface-container-highest
   );
-  --color-on-surface: var(--md-sys-color-on-surface);
-  --color-on-surface-variant: var(--md-sys-color-on-surface-variant);
-  --color-outline: var(--md-sys-color-outline);
-  --color-outline-variant: var(--md-sys-color-outline-variant);
-  --color-inverse-surface: var(--md-sys-color-inverse-surface);
-  --color-inverse-on-surface: var(--md-sys-color-inverse-on-surface);
-  --color-primary: var(--md-sys-color-primary);
-  --color-on-primary: var(--md-sys-color-on-primary);
-  --color-primary-container: var(--md-sys-color-primary-container);
-  --color-on-primary-container: var(--md-sys-color-on-primary-container);
-  --color-primary-fixed: var(--md-sys-color-primary-fixed);
-  --color-primary-fixed-dim: var(--md-sys-color-primary-fixed-dim);
-  --color-on-primary-fixed: var(--md-sys-color-on-primary-fixed);
-  --color-on-primary-fixed-variant: var(
-    --md-sys-color-on-primary-fixed-variant
+  --color-surface-container-low: var(--md-sys-color-surface-container-low);
+  --color-surface-container-lowest: var(
+    --md-sys-color-surface-container-lowest
   );
-  --color-inverse-primary: var(--md-sys-color-inverse-primary);
-  --color-secondary: var(--md-sys-color-secondary);
-  --color-on-secondary: var(--md-sys-color-on-secondary);
-  --color-secondary-container: var(--md-sys-color-secondary-container);
-  --color-on-secondary-container: var(--md-sys-color-on-secondary-container);
-  --color-secondary-fixed: var(--md-sys-color-secondary-fixed);
-  --color-secondary-fixed-dim: var(--md-sys-color-secondary-fixed-dim);
-  --color-on-secondary-fixed: var(--md-sys-color-on-secondary-fixed);
-  --color-on-secondary-fixed-variant: var(
-    --md-sys-color-on-secondary-fixed-variant
-  );
+  --color-surface-dim: var(--md-sys-color-surface-dim);
+  --color-surface-tint: var(--md-sys-color-surface-tint);
+  --color-surface-variant: var(--md-sys-color-surface-variant);
   --color-tertiary: var(--md-sys-color-tertiary);
-  --color-on-tertiary: var(--md-sys-color-on-tertiary);
   --color-tertiary-container: var(--md-sys-color-tertiary-container);
-  --color-on-tertiary-container: var(--md-sys-color-on-tertiary-container);
   --color-tertiary-fixed: var(--md-sys-color-tertiary-fixed);
   --color-tertiary-fixed-dim: var(--md-sys-color-tertiary-fixed-dim);
-  --color-on-tertiary-fixed: var(--md-sys-color-on-tertiary-fixed);
-  --color-on-tertiary-fixed-variant: var(
-    --md-sys-color-on-tertiary-fixed-variant
-  );
-  --color-error: var(--md-sys-color-error);
-  --color-on-error: var(--md-sys-color-on-error);
-  --color-error-container: var(--md-sys-color-error-container);
-  --color-on-error-container: var(--md-sys-color-on-error-container);
-  --color-scrim: var(--md-sys-color-scrim);
-  --color-shadow: var(--md-sys-color-shadow);
 
   /* Shades */
 
@@ -130,50 +132,4 @@
   --color-neutral-variant-800: var(--md-ref-palette-neutral-variant-20);
   --color-neutral-variant-900: var(--md-ref-palette-neutral-variant-10);
   --color-neutral-variant-950: var(--md-ref-palette-neutral-variant-5);
-
-  /*
-   * Custom colors
-   */
-
-  --color-myCustomColor1: var(--md-sys-color-my-custom-color-1);
-  --color-on-myCustomColor1: var(--md-sys-color-on-my-custom-color-1);
-  --color-myCustomColor1-container: var(
-    --md-sys-color-my-custom-color-1-container
-  );
-  --color-on-myCustomColor1-container: var(
-    --md-sys-color-on-my-custom-color-1-container
-  );
-  /* Shades */
-  --color-myCustomColor1-50: var(--md-ref-palette-my-custom-color-1-95);
-  --color-myCustomColor1-100: var(--md-ref-palette-my-custom-color-1-90);
-  --color-myCustomColor1-200: var(--md-ref-palette-my-custom-color-1-80);
-  --color-myCustomColor1-300: var(--md-ref-palette-my-custom-color-1-70);
-  --color-myCustomColor1-400: var(--md-ref-palette-my-custom-color-1-60);
-  --color-myCustomColor1-500: var(--md-ref-palette-my-custom-color-1-50);
-  --color-myCustomColor1-600: var(--md-ref-palette-my-custom-color-1-40);
-  --color-myCustomColor1-700: var(--md-ref-palette-my-custom-color-1-30);
-  --color-myCustomColor1-800: var(--md-ref-palette-my-custom-color-1-20);
-  --color-myCustomColor1-900: var(--md-ref-palette-my-custom-color-1-10);
-  --color-myCustomColor1-950: var(--md-ref-palette-my-custom-color-1-5);
-
-  --color-myCustomColor2: var(--md-sys-color-my-custom-color-2);
-  --color-on-myCustomColor2: var(--md-sys-color-on-my-custom-color-2);
-  --color-myCustomColor2-container: var(
-    --md-sys-color-my-custom-color-2-container
-  );
-  --color-on-myCustomColor2-container: var(
-    --md-sys-color-on-my-custom-color-2-container
-  );
-  /* Shades */
-  --color-myCustomColor2-50: var(--md-ref-palette-my-custom-color-2-95);
-  --color-myCustomColor2-100: var(--md-ref-palette-my-custom-color-2-90);
-  --color-myCustomColor2-200: var(--md-ref-palette-my-custom-color-2-80);
-  --color-myCustomColor2-300: var(--md-ref-palette-my-custom-color-2-70);
-  --color-myCustomColor2-400: var(--md-ref-palette-my-custom-color-2-60);
-  --color-myCustomColor2-500: var(--md-ref-palette-my-custom-color-2-50);
-  --color-myCustomColor2-600: var(--md-ref-palette-my-custom-color-2-40);
-  --color-myCustomColor2-700: var(--md-ref-palette-my-custom-color-2-30);
-  --color-myCustomColor2-800: var(--md-ref-palette-my-custom-color-2-20);
-  --color-myCustomColor2-900: var(--md-ref-palette-my-custom-color-2-10);
-  --color-myCustomColor2-950: var(--md-ref-palette-my-custom-color-2-5);
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,12 +1,18 @@
-import { copyFileSync } from "fs";
+import { copyFileSync, rmSync } from "fs";
 import { defineConfig } from "tsup";
+
+// Clean once, up front, instead of `clean: true`: the configs below build in
+// parallel, and a `clean: true` dts build deletes every `*.d.ts` in outDir
+// when it completes -- wiping whichever sibling dts happened to finish first.
+rmSync("dist", { recursive: true, force: true });
 
 // Three bundles rather than one, so that `"use client"` lands only on the
 // React surface -- and so that nothing on the root entry points at it:
 //
-//   dist/index.js   no directive -- `builder`, the package root
-//   dist/react.js   "use client" -- Mtb, useMcu, ExportButton
-//   dist/cli.js     the CLI
+//   dist/index.js            no directive -- `builder`, the package root
+//   dist/tailwind-plugin.js  no directive -- the Tailwind 4 plugin (Node-only)
+//   dist/react.js            "use client" -- Mtb, useMcu, ExportButton
+//   dist/cli.js              the CLI
 //
 // The two are independent: `index.js` does not import `react.js`, which is
 // what keeps `import { builder } from "material-theme-builder"` free of React
@@ -17,7 +23,7 @@ import { defineConfig } from "tsup";
 const shared = {
   format: ["esm"] as const,
   outDir: "dist",
-  external: ["react", "react-dom"],
+  external: ["react", "react-dom", /^tailwindcss/],
   esbuildOptions(options: { jsx?: string }) {
     options.jsx = "automatic";
   },
@@ -26,9 +32,8 @@ const shared = {
 export default defineConfig([
   {
     ...shared,
-    entryPoints: ["src/index.ts"],
+    entryPoints: ["src/index.ts", "src/tailwind-plugin.ts"],
     dts: true,
-    clean: true,
     onSuccess: async () => {
       // Copy tailwind.css to dist
       copyFileSync("src/tailwind.css", "dist/tailwind.css");


### PR DESCRIPTION
## What

A [Tailwind 4 plugin](https://tailwindcss.com/docs/functions-and-directives#plugin-directive) exposed as `material-theme-builder/tailwind`. One line replaces the whole manual `@theme inline` block from the README — custom colors included, which used to require ~15 hand-written declarations each:

```css
@import "tailwindcss";
@plugin "material-theme-builder/tailwind" {
  custom-colors: myCustomColor1, myCustomColor2;
}
```

→ `bg-primary`, `text-on-surface`, `bg-primary-100`, `bg-my-custom-color-1`, `text-on-my-custom-color-1-container`, `bg-my-custom-color-1-50`…`950`, etc., all backed by the `--md-sys-color-*` / `--md-ref-palette-*` variables `<Mtb>`/`toCss()` inject.

### Options

- `custom-colors` — custom color name(s) (Tailwind parses comma-separated `@plugin` values into arrays natively). Names cannot be discovered at build time (they live in JS at runtime), so this one-liner is the whole remaining duplication.
- `prefix` — CSS variable prefix (default `md`)

A `config: "./file.json"` option (shared file with `<Mtb>`, zero duplication) was considered and dropped: Tailwind wouldn't watch the file (silently stale builds until dev-server restart) and the path could only resolve from cwd (fragile in monorepos). The one-line `custom-colors` duplication is the lesser evil.

## Implementation

- `src/tailwind-plugin.ts` — thin `plugin.withOptions()` entry
- `tailwindThemeColors()` in `src/lib/builder.tailwind.ts` — the flat colors record, sharing `SHADE_TO_TONE`/`CORE_PALETTES` and the custom-token naming with `toTailwind()`
- `tailwindcss` added as an **optional** peer dependency (`^4.0.0`)

## Drive-by fixes

- **`dist/tailwind.css` was stale and shipped placeholders**: it lacked `--color-surface-tint`/`--color-surface-variant` and contained the README's `myCustomColor1`/`myCustomColor2` example entries. It is now generated from `toTailwind()`, and a parity test locks the plugin, `toTailwind()` and the static file together.
- **tsup race**: with parallel configs, a `clean: true` dts build deletes every `*.d.ts` in outDir on completion — adding the plugin entry made config 1's dts slower than react's, so `dist/react.d.ts` got wiped intermittently (caught by `check-exports` in the pre-commit hook). dist is now cleaned once at config load instead.

## Tests

- Unit: standard tokens/shades, custom-color list, `prefix`, and **parity** with both `toTailwind()` output and the static `tailwind.css`
- E2E (manual): compiled through the real `@tailwindcss/postcss` pipeline — `@plugin "material-theme-builder/tailwind" { custom-colors: myCustomColor1, brandy; }` generates all expected utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfWuXervnssDZqK9H6JEQT
