### PR TITLE
feat: add a `ThemePanel` debug component

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ return (
 );
 ```
 
+## `ThemePanel`
+
+A debug panel (à la [Radix Themes](https://www.radix-ui.com/themes/docs/components/theme-panel)) to tweak the theme live — source color, palette overrides, custom colors, scheme and contrast:
+
+```tsx
+import { Mtb, ThemePanel } from "material-theme-builder/react";
+
+<Mtb source="#769CDF">
+  <ThemePanel />
+</Mtb>;
+```
+
 ## Tailwind
 
 Compatible through [theme variables](https://tailwindcss.com/docs/theme):

--- a/src/Flowfield.stories.helpers.tsx
+++ b/src/Flowfield.stories.helpers.tsx
@@ -1,49 +1,11 @@
-import { hexFromArgb } from "@material/material-color-utilities";
 import { kebabCase } from "lodash-es";
-import { MoonIcon, SunIcon, X } from "lucide-react";
-import {
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-  type ComponentProps,
-} from "react";
-import { useDebounceCallback } from "usehooks-ts";
-import { Button } from "./components/ui/button";
-import { ButtonGroup } from "./components/ui/button-group";
+import { MoonIcon, SunIcon } from "lucide-react";
+import { useCallback, useMemo, useState, type ComponentProps } from "react";
 import { Toggle } from "./components/ui/toggle";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "./components/ui/tooltip";
 import { Flowfield, type Peak } from "./Flowfield";
-import { schemeNames } from "./lib/builder";
 import { cn } from "./lib/utils";
 import { useMcu } from "./Mcu.context";
-
-function Pill({
-  color,
-  children,
-  className,
-  ...props
-}: {
-  /** Background color (hex string). */
-  color?: string;
-} & ComponentProps<"span">) {
-  return (
-    <span
-      className={cn(
-        "size-6 rounded-full border overflow-hidden shrink-0",
-        className,
-      )}
-      style={{ backgroundColor: color ?? "transparent" }}
-      {...props}
-    >
-      {children}
-    </span>
-  );
-}
+import { ThemePanel } from "./ThemePanel";
 
 /**
  * Toggle that adds/removes the `dark` class on the closest `<html>` element.
@@ -72,58 +34,10 @@ function DarkModeToggle() {
 }
 
 /**
- * Color button
- */
-function ButtonPill({
-  color,
-  onChange,
-  ...rest
-}: {
-  /** Current color (hex string). */
-  color?: string;
-  /** Called with the newly picked hex color. */
-  onChange: (hex: string) => void;
-} & Omit<React.ComponentProps<typeof Button>, "color" | "onChange">) {
-  const inputColorRef = useRef<HTMLInputElement>(null);
-
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      onClick={() => {
-        inputColorRef.current?.click();
-      }}
-      {...rest}
-    >
-      <Pill color={color}>
-        <input
-          tabIndex={-1}
-          ref={inputColorRef}
-          type="color"
-          value={color ?? ""}
-          onChange={(e) => onChange(e.target.value)}
-          className="opacity-0"
-        />
-      </Pill>
-    </Button>
-  );
-}
-
-/**
  * Flowfield scene with color palette controls overlay.
  */
 export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
-  const {
-    allPalettes,
-    mcuConfig,
-    setMcuConfig: _setMcuConfig,
-    initials,
-  } = useMcu();
-
-  const setMcuConfig = useDebounceCallback(_setMcuConfig, 50);
-
-  const pendingAddIndexRef = useRef<number | null>(null);
+  const { allPalettes } = useMcu();
 
   const baseColors = useMemo<Record<number, string>>(
     () => ({
@@ -163,195 +77,9 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
   return (
     <>
       <Flowfield peaks={peaks} baseColors={baseColors} {...props} />
-      <div className={cn("fixed bottom-0 left-0 m-6", "flex items-end gap-2")}>
-        <div className="flex flex-col-reverse">
-          {(
-            [
-              {
-                key: "primary",
-                label: "Primary",
-                color: mcuConfig.primary ?? initials.source,
-              },
-              {
-                key: "secondary",
-                label: "Secondary",
-                color: mcuConfig.secondary,
-              },
-              { key: "tertiary", label: "Tertiary", color: mcuConfig.tertiary },
-              { key: "error", label: "Error", color: mcuConfig.error },
-              { key: "neutral", label: "Neutral", color: mcuConfig.neutral },
-              {
-                key: "neutralVariant",
-                label: "Neutral variant",
-                color: mcuConfig.neutralVariant,
-              },
-            ] as const
-          ).map(({ key, label, color }) => {
-            const paletteKey = kebabCase(key);
-            const isInferred = mcuConfig[key] === undefined;
-            const inferredHex = isInferred
-              ? hexFromArgb(allPalettes[paletteKey]?.keyColor.toInt() ?? 0)
-              : undefined;
-
-            return (
-              <Tooltip key={key}>
-                <TooltipTrigger asChild>
-                  <ButtonPill
-                    color={color}
-                    onChange={(hex) => {
-                      setMcuConfig({
-                        ...mcuConfig,
-                        [key]: hex,
-                      });
-                    }}
-                  />
-                </TooltipTrigger>
-                <TooltipContent side="right">
-                  <span className="flex items-center gap-1">
-                    {!isInferred && (
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        onClick={() =>
-                          setMcuConfig({ ...mcuConfig, [key]: undefined })
-                        }
-                        className="-ml-1"
-                      >
-                        <X />
-                      </Button>
-                    )}
-                    {label}
-                    {inferredHex && (
-                      <Pill color={inferredHex} className="size-3" />
-                    )}
-                  </span>
-                </TooltipContent>
-              </Tooltip>
-            );
-          })}
-
-          {/* Custom color */}
-
-          <hr className="my-1 border-t border-outline-variant w-6 mx-auto" />
-
-          {(mcuConfig.customColors ?? []).map(({ name, hex }, i) => (
-            <Tooltip key={name}>
-              <TooltipTrigger asChild>
-                <ButtonPill
-                  color={hex}
-                  onChange={(newHex) => {
-                    const updated = (mcuConfig.customColors ?? []).map(
-                      (c, j) => (j === i ? { ...c, hex: newHex } : c),
-                    );
-                    setMcuConfig({
-                      ...mcuConfig,
-                      customColors: updated,
-                    });
-                  }}
-                />
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                <span className="flex items-center gap-1">
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    onClick={() => {
-                      const updated = (mcuConfig.customColors ?? []).filter(
-                        (_, j) => j !== i,
-                      );
-                      setMcuConfig({ ...mcuConfig, customColors: updated });
-                    }}
-                    className="-ml-1"
-                  >
-                    <X />
-                  </Button>
-                  {name}
-                </span>
-              </TooltipContent>
-            </Tooltip>
-          ))}
-
-          {/* Add new custom color */}
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ButtonPill
-                onClick={() => {
-                  pendingAddIndexRef.current = null;
-                }}
-                onChange={(hex) => {
-                  const existing = mcuConfig.customColors ?? [];
-                  const idx = pendingAddIndexRef.current;
-
-                  if (idx !== null && idx < existing.length) {
-                    // update the color being picked
-                    const updated = existing.map((c, j) =>
-                      j === idx ? { ...c, hex } : c,
-                    );
-                    setMcuConfig({ ...mcuConfig, customColors: updated });
-                  } else {
-                    // first change of this pick session — add a new color
-                    pendingAddIndexRef.current = existing.length;
-                    setMcuConfig({
-                      ...mcuConfig,
-                      customColors: [
-                        ...existing,
-                        {
-                          name: `customColor${existing.length + 1}`,
-                          hex,
-                          blend: true,
-                        },
-                      ],
-                    });
-                  }
-                }}
-              />
-            </TooltipTrigger>
-            <TooltipContent side="right">Add custom color</TooltipContent>
-          </Tooltip>
-        </div>
+      <div className={cn("fixed top-0 left-0 m-6", "flex items-center gap-2")}>
+        <ThemePanel />
         <DarkModeToggle />
-
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            const levels = [
-              { label: "Std", value: 0 },
-              { label: "Med", value: 0.5 },
-              { label: "Hi", value: 1 },
-            ] as const;
-            const current = mcuConfig.contrast ?? 0;
-            const idx = levels.findIndex((l) => l.value === current);
-            const next = levels[(idx + 1) % levels.length] ?? levels[0];
-            setMcuConfig({ ...mcuConfig, contrast: next.value });
-          }}
-        >
-          {(
-            [
-              { label: "Std", value: 0 },
-              { label: "Med", value: 0.5 },
-              { label: "Hi", value: 1 },
-            ] as const
-          ).find((l) => l.value === (mcuConfig.contrast ?? 0))?.label ?? "Std"}
-        </Button>
-        <div>
-          <ButtonGroup>
-            <Button
-              size="sm"
-              variant="outline"
-              className="capitalize"
-              onClick={() => {
-                const currentScheme = mcuConfig.scheme ?? "tonalSpot";
-                const idx = schemeNames.indexOf(currentScheme);
-                const next = schemeNames[(idx + 1) % schemeNames.length];
-                setMcuConfig({ ...mcuConfig, scheme: next });
-              }}
-            >
-              {mcuConfig.scheme ?? "tonalSpot"}
-            </Button>
-          </ButtonGroup>
-        </div>
       </div>
     </>
   );

--- a/src/ThemePanel.tsx
+++ b/src/ThemePanel.tsx
@@ -1,0 +1,390 @@
+import { hexFromArgb } from "@material/material-color-utilities";
+import { kebabCase } from "lodash-es";
+import { Contrast, X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentProps,
+} from "react";
+import { useDebounceCallback } from "usehooks-ts";
+import { Button } from "./components/ui/button";
+import { ButtonGroup } from "./components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "./components/ui/tooltip";
+import { schemeNames, type McuConfig } from "./lib/builder";
+import { cn } from "./lib/utils";
+import { useMcu } from "./Mcu.context";
+
+const CONTRAST_LEVELS = [
+  { label: "Standard", value: 0 },
+  { label: "Medium", value: 0.5 },
+  { label: "High", value: 1 },
+] as const;
+
+function clickColorInput(e: React.MouseEvent<HTMLButtonElement>) {
+  e.currentTarget
+    .querySelector<HTMLInputElement>('input[type="color"]')
+    ?.click();
+}
+
+/**
+ * A small round colour swatch — the visual face of every colour-picker button.
+ */
+function Pill({
+  color,
+  children,
+  className,
+  ...props
+}: {
+  /** The swatch colour (any CSS colour, vars included) — transparent when absent. */
+  color?: string;
+} & ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "size-4 rounded-full border overflow-hidden shrink-0",
+        className,
+      )}
+      style={{ backgroundColor: color ?? "transparent" }}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+/**
+ * Theme configuration panel — a debug UI for the MCU theme.
+ *
+ * Lets users customise the Material color scheme: source color,
+ * palette overrides, custom colors, scheme variant, and contrast level.
+ *
+ * Must be rendered inside `<Mtb>` (it drives the theme via {@link useMcu}).
+ *
+ * @example
+ * ```tsx
+ * <Mtb source="#769CDF">
+ *   <ThemePanel />
+ * </Mtb>
+ * ```
+ */
+export function ThemePanel(props: ComponentProps<typeof ButtonGroup>) {
+  const { initials, setMcuConfig, allPalettes } = useMcu();
+
+  const [config, setConfig] = useState<McuConfig>(() => initials);
+
+  const pendingAddIndexRef = useRef<number | null>(null);
+  const sourceInputRef = useRef<HTMLInputElement>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const update = useCallback((patch: Partial<McuConfig>) => {
+    setConfig((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  // Apply the config whenever it changes — debounced, since dragging a color
+  // input fires on every frame and each application rebuilds the whole theme
+  const applyConfig = useDebounceCallback(setMcuConfig, 50);
+  useEffect(() => {
+    applyConfig(config);
+  }, [config, applyConfig]);
+
+  const paletteRows = useMemo(
+    () =>
+      [
+        { key: "primary", label: "Primary", color: config.primary },
+        { key: "secondary", label: "Secondary", color: config.secondary },
+        { key: "tertiary", label: "Tertiary", color: config.tertiary },
+        { key: "error", label: "Error", color: config.error },
+        { key: "neutral", label: "Neutral", color: config.neutral },
+        {
+          key: "neutralVariant",
+          label: "Neutral variant",
+          color: config.neutralVariant,
+        },
+      ] as const,
+    [config],
+  );
+
+  const effectiveColor = expanded
+    ? config.source
+    : (config.primary ?? config.source);
+
+  return (
+    <ButtonGroup {...props}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon"
+            className="relative"
+            onClick={() => setExpanded((v) => !v)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                sourceInputRef.current?.click();
+              }
+            }}
+          >
+            <Pill
+              color={effectiveColor}
+              onClick={(e) => {
+                e.stopPropagation();
+                sourceInputRef.current?.click();
+              }}
+            />
+            <input
+              tabIndex={-1}
+              ref={sourceInputRef}
+              type="color"
+              value={effectiveColor ?? ""}
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => {
+                if (expanded || config.primary === undefined) {
+                  update({ source: e.target.value });
+                } else {
+                  update({ primary: e.target.value });
+                }
+              }}
+              className="opacity-0 absolute bottom-0 left-0 right-0 h-0 pointer-events-none"
+            />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Source color</TooltipContent>
+      </Tooltip>
+
+      {expanded && (
+        <>
+          {paletteRows.map(({ key, label, color }) => {
+            const paletteKey = kebabCase(key);
+            const isInferred = config[key] === undefined;
+            const inferredHex = isInferred
+              ? hexFromArgb(allPalettes[paletteKey]?.keyColor.toInt() ?? 0)
+              : undefined;
+
+            return (
+              <Tooltip key={key}>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="relative"
+                    onClick={clickColorInput}
+                  >
+                    <Pill color={color} />
+                    <input
+                      tabIndex={-1}
+                      type="color"
+                      value={color ?? inferredHex ?? ""}
+                      onChange={(e) => update({ [key]: e.target.value })}
+                      className="opacity-0 absolute bottom-0 left-0 right-0 h-0 pointer-events-none"
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <span className="flex items-center gap-1">
+                    {!isInferred && (
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={() => update({ [key]: undefined })}
+                      >
+                        <X />
+                      </Button>
+                    )}
+                    {label}
+                    {inferredHex && (
+                      <Pill color={inferredHex} className="size-3" />
+                    )}
+                  </span>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+
+          {/* Custom colors */}
+
+          {(config.customColors ?? []).map(({ name, hex }, i) => (
+            <Tooltip key={name}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="relative"
+                  onClick={clickColorInput}
+                >
+                  <Pill color={hex} />
+                  <input
+                    tabIndex={-1}
+                    type="color"
+                    value={hex}
+                    onChange={(e) => {
+                      const updated = (config.customColors ?? []).map((c, j) =>
+                        j === i ? { ...c, hex: e.target.value } : c,
+                      );
+                      update({ customColors: updated });
+                    }}
+                    className="opacity-0 absolute bottom-0 left-0 right-0 h-0 pointer-events-none"
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <span className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={() => {
+                      const updated = (config.customColors ?? []).filter(
+                        (_, j) => j !== i,
+                      );
+                      update({ customColors: updated });
+                    }}
+                  >
+                    <X />
+                  </Button>
+                  {name}
+                </span>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+
+          {/* Add custom color */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                className="relative"
+                onClick={clickColorInput}
+              >
+                <Pill />
+                <input
+                  tabIndex={-1}
+                  type="color"
+                  onChange={(e) => {
+                    const hex = e.target.value;
+                    const existing = config.customColors ?? [];
+                    const idx = pendingAddIndexRef.current;
+
+                    if (idx !== null && idx < existing.length) {
+                      const updated = existing.map((c, j) =>
+                        j === idx ? { ...c, hex } : c,
+                      );
+                      update({ customColors: updated });
+                    } else {
+                      pendingAddIndexRef.current = existing.length;
+                      update({
+                        customColors: [
+                          ...existing,
+                          {
+                            name: `customColor${existing.length + 1}`,
+                            hex,
+                            blend: true,
+                          },
+                        ],
+                      });
+                    }
+                  }}
+                  className="opacity-0 absolute bottom-0 left-0 right-0 h-0 pointer-events-none"
+                />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Add custom color</TooltipContent>
+          </Tooltip>
+        </>
+      )}
+
+      <ContrastToggle
+        contrast={config.contrast}
+        onChange={(v) => update({ contrast: v })}
+      />
+
+      <SchemeToggle
+        scheme={config.scheme}
+        onChange={(v) => update({ scheme: v })}
+      />
+    </ButtonGroup>
+  );
+}
+
+const CONTRAST_ICON_SIZE: Record<number, string> = {
+  0: "size-4",
+  0.5: "size-5",
+  1: "size-6",
+};
+
+/**
+ * Cycles through contrast levels on click.
+ */
+function ContrastToggle({
+  contrast,
+  onChange,
+}: {
+  contrast?: number;
+  onChange: (v: number) => void;
+}) {
+  const current = contrast ?? 0;
+  const currentLevel =
+    CONTRAST_LEVELS.find((l) => l.value === current) ?? CONTRAST_LEVELS[0];
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => {
+            const i = CONTRAST_LEVELS.findIndex((l) => l.value === current);
+            const next =
+              CONTRAST_LEVELS[(i + 1) % CONTRAST_LEVELS.length] ??
+              CONTRAST_LEVELS[0];
+            onChange(next.value);
+          }}
+        >
+          <Contrast className={CONTRAST_ICON_SIZE[current] ?? "size-4"} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        Contrast: {currentLevel.label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * Cycles through scheme variants on click.
+ */
+function SchemeToggle({
+  scheme,
+  onChange,
+}: {
+  scheme?: (typeof schemeNames)[number];
+  onChange: (v: (typeof schemeNames)[number]) => void;
+}) {
+  const current = scheme ?? "tonalSpot";
+  const i = schemeNames.indexOf(current);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="outline"
+          onClick={() =>
+            onChange(
+              schemeNames[(i + 1) % schemeNames.length] ?? schemeNames[0],
+            )
+          }
+        >
+          {current === "tonalSpot"
+            ? "TonalSpot"
+            : current.charAt(0).toUpperCase() + current.slice(1)}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Scheme variant</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/react.ts
+++ b/src/react.ts
@@ -6,3 +6,4 @@
 export { ExportButton } from "./ExportButton";
 export { useMcu } from "./Mcu.context";
 export { Mcu, Mtb } from "./Mtb";
+export { ThemePanel } from "./ThemePanel";


### PR DESCRIPTION
Adds a `ThemePanel` component to `material-theme-builder/react` — a drop-in debug panel (à la [Radix Themes' `ThemePanel`](https://www.radix-ui.com/themes/docs/components/theme-panel)) for tweaking the MCU theme live: source color, per-palette overrides, custom colors, scheme variant and contrast level.

```tsx
import { Mtb, ThemePanel } from "material-theme-builder/react";

<Mtb source="#769CDF">
  <ThemePanel />
</Mtb>;
```

- Ported from the sizematters app's `ColorPalettePanel`, stripped of its app-specific machinery (react-intl, image-derived palette, localStorage cache).
- Theme application is debounced (50ms): dragging a color input fires on every frame and each application rebuilds the whole theme.
- The Flowfield story now renders `<ThemePanel />` in place of its ~200-line inline palette overlay.
- README: new `ThemePanel` section.

Note: styles are Tailwind classes bundled in the JS — consumers must let their Tailwind scan the package (e.g. `@source "../node_modules/material-theme-builder/dist";`), same constraint as `ExportButton`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyTbaYR8iH4e7ehPYpeQgX
