### PR TITLE
feat: finish the `Mcu` → `Mtb` rename (`useMtb`, `MtbConfig`, `Mtb.context`)

### DIFF
--- a/.changeset/mcu-renamed-mtb.md
+++ b/.changeset/mcu-renamed-mtb.md
@@ -2,4 +2,4 @@
 "material-theme-builder": minor
 ---
 
-Rename the `Mcu` component to `Mtb`. `Mcu` still works as a deprecated alias of `Mtb` (same component, same props) and will be removed in the next major.
+Rename the `Mcu` React surface to `Mtb`: the `Mcu` component is now `Mtb`, the `useMcu` hook is now `useMtb`, and the `McuConfig` type is now `MtbConfig`. The old names still work as deprecated aliases (same component, same hook, same shape) and will be removed in the next major.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ The React bindings live on their own entry point, `material-theme-builder/react`
 CSS variables are injected into the page:
 
 ```tsx
-import { Mcu } from "material-theme-builder/react";
+import { Mtb } from "material-theme-builder/react";
 
-<Mcu
+<Mtb
   source="#0e1216"
   scheme="vibrant"
   contrast={0.5}
@@ -88,7 +88,7 @@ import { Mcu } from "material-theme-builder/react";
       color: "var(--md-sys-color-on-my-custom-color-1)",
     }}>colors<span>!
   </p>
-</Mcu>
+</Mtb>
 ```
 
 > [!TIP]
@@ -103,20 +103,20 @@ import { Mcu } from "material-theme-builder/react";
 
 > [!NOTE]
 >
-> `<Mcu>` injects the CSS from the client, and is the only thing here carrying
+> `<Mtb>` injects the CSS from the client, and is the only thing here carrying
 > `"use client"`. The root entry holds `builder` alone — so from a
 > [React Server Component](https://react.dev/reference/rsc/server-components)
 > you can call it and emit `toCss()` into the document yourself, without
 > shipping components the page never renders.
 
-## `useMcu`
+## `useMtb`
 
 A hook is also provided:
 
 ```tsx
-import { useMcu } from "material-theme-builder/react";
+import { useMtb } from "material-theme-builder/react";
 
-const { initials, setMcuConfig, getMcuColor } = useMcu();
+const { initials, setMcuConfig, getMcuColor } = useMtb();
 
 return (
   <button onClick={() => setMcuConfig({ ...initials, source: "#FF5722" })}>

--- a/figma-plugin/src/main.tsx
+++ b/figma-plugin/src/main.tsx
@@ -3,15 +3,15 @@ import { createRoot } from "react-dom/client";
 import { Fab } from "../../src/components/m3/Fab";
 import { FlowfieldSt } from "../../src/Flowfield.stories";
 import { FlowfieldScene } from "../../src/Flowfield.stories.helpers";
-import { useMcu } from "../../src/Mcu.context";
 import { Mtb } from "../../src/Mtb";
+import { useMtb } from "../../src/Mtb.context";
 
 import { TooltipProvider } from "../../src/components/ui/tooltip";
 import "../../src/styles/globals.css";
 import "./main.css";
 
 function SyncButton() {
-  const { figmaVariables } = useMcu();
+  const { figmaVariables } = useMtb();
   const [syncing, setSyncing] = useState(false);
 
   function handleSync() {

--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -1,10 +1,10 @@
 import { Fab } from "./components/m3/Fab";
-import type { McuConfig } from "./lib/builder";
+import type { MtbConfig } from "./lib/builder";
 import { builder } from "./lib/builder";
 
 interface ExportButtonProps {
   /** Current theme configuration used to generate the exported tokens. */
-  config: McuConfig;
+  config: MtbConfig;
 }
 
 /**

--- a/src/Flowfield.stories.helpers.tsx
+++ b/src/Flowfield.stories.helpers.tsx
@@ -20,7 +20,7 @@ import {
 import { Flowfield, type Peak } from "./Flowfield";
 import { schemeNames } from "./lib/builder";
 import { cn } from "./lib/utils";
-import { useMcu } from "./Mcu.context";
+import { useMtb } from "./Mtb.context";
 
 function Pill({
   color,
@@ -119,7 +119,7 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
     mcuConfig,
     setMcuConfig: _setMcuConfig,
     initials,
-  } = useMcu();
+  } = useMtb();
 
   const setMcuConfig = useDebounceCallback(_setMcuConfig, 50);
 

--- a/src/Mtb.context.tsx
+++ b/src/Mtb.context.tsx
@@ -7,38 +7,38 @@ import {
   builder,
   type FigmaTokens,
   type FigmaVariable,
-  type McuConfig,
+  type MtbConfig,
   type TokenName,
 } from "./lib/builder";
 import { createRequiredContext } from "./lib/createRequiredContext";
 
 type Api = {
-  initials: McuConfig;
-  mcuConfig: McuConfig;
-  setMcuConfig: (config: McuConfig) => void;
+  initials: MtbConfig;
+  mcuConfig: MtbConfig;
+  setMcuConfig: (config: MtbConfig) => void;
   getMcuColor: (colorName: TokenName, theme?: string) => string;
   allPalettes: Record<string, TonalPalette>;
   figmaTokens: FigmaTokens;
   figmaVariables: FigmaVariable[];
 };
 
-const [useMcu, Provider, McuContext] = createRequiredContext<Api>();
+const [useMtb, Provider, MtbContext] = createRequiredContext<Api>();
 
 /**
  * Provider that computes the Material You theme and exposes it via context.
  */
-export const McuProvider = ({
+export const MtbProvider = ({
   styleId,
   children,
   ...configProps
-}: McuConfig & {
+}: MtbConfig & {
   /** The `id` attribute applied to the injected `<style>` element. */
   styleId: string;
   /** Content to render inside the provider. */
   children?: React.ReactNode;
 }) => {
   const [initials] = useState(() => configProps);
-  // console.log("McuProvider initials", initials);
+  // console.log("MtbProvider initials", initials);
 
   const [mcuConfig, setMcuConfig] = useState(initials);
 
@@ -137,4 +137,10 @@ export const McuProvider = ({
   );
 };
 
-export { McuContext, useMcu };
+/**
+ * @deprecated Renamed `useMtb` — same hook, same return value. This alias will
+ * be removed in the next major.
+ */
+const useMcu = useMtb;
+
+export { MtbContext, useMcu, useMtb };

--- a/src/Mtb.stories.helpers.tsx
+++ b/src/Mtb.stories.helpers.tsx
@@ -4,8 +4,8 @@ import { type ComponentProps } from "react";
 import { ExportButton } from "./ExportButton";
 import { STANDARD_TONES } from "./lib/builder";
 import { cn } from "./lib/utils";
-import { useMcu } from "./Mcu.context";
 import type { Mtb } from "./Mtb";
+import { useMtb } from "./Mtb.context";
 
 function Foo({ children, ...props }: ComponentProps<"div">) {
   return (
@@ -40,7 +40,7 @@ export function Layout({
   /** Story content to render inside the layout. */
   children: React.ReactNode;
 }) {
-  const { initials } = useMcu();
+  const { initials } = useMtb();
 
   return (
     <div className="flex flex-col gap-6 max-w-208 mx-auto">

--- a/src/Mtb.stories.tsx
+++ b/src/Mtb.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useMemo } from "react";
 import { allModes } from "../.storybook/modes";
-import { type McuConfig, schemeNames } from "./lib/builder";
+import { type MtbConfig, schemeNames } from "./lib/builder";
 import { recolorizeSvg } from "./lib/recolorizeSvg";
-import { useMcu } from "./Mcu.context";
 import { Mtb } from "./Mtb";
+import { useMtb } from "./Mtb.context";
 import { Layout, Scheme, Shades, TailwindScheme } from "./Mtb.stories.helpers";
 
 import exampleSvg from "./assets/example.svg?raw";
@@ -651,7 +651,7 @@ const RecolorizedIllustration = ({
   palettes,
 }: {
   svgContent: string;
-  palettes: ReturnType<typeof useMcu>["allPalettes"];
+  palettes: ReturnType<typeof useMtb>["allPalettes"];
 }) => {
   const recoloredSvg = useMemo(() => {
     return recolorizeSvg(svgContent, palettes);
@@ -667,11 +667,11 @@ function Scene({
   excludedPalettesNames = [], // palettes to exclude
 }: {
   svgContent?: string;
-  customColors?: McuConfig["customColors"];
+  customColors?: MtbConfig["customColors"];
   includedPalettesNames?: string[];
   excludedPalettesNames?: string[];
 }) {
-  const { allPalettes } = useMcu();
+  const { allPalettes } = useMtb();
 
   let palettes = allPalettes;
 

--- a/src/Mtb.test.tsx
+++ b/src/Mtb.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it } from "vitest";
 import { Mcu, Mtb } from "./Mtb";
+import { useMcu, useMtb } from "./Mtb.context";
 
 describe("Mtb", () => {
   afterEach(() => {
@@ -130,5 +131,9 @@ describe("Mtb", () => {
 
   it("should keep `Mcu` as a deprecated alias of `Mtb`", () => {
     expect(Mcu).toBe(Mtb);
+  });
+
+  it("should keep `useMcu` as a deprecated alias of `useMtb`", () => {
+    expect(useMcu).toBe(useMtb);
   });
 });

--- a/src/Mtb.tsx
+++ b/src/Mtb.tsx
@@ -6,9 +6,9 @@ import {
   DEFAULT_CUSTOM_COLORS,
   DEFAULT_PREFIX,
   DEFAULT_SCHEME,
-  type McuConfig,
+  type MtbConfig,
 } from "./lib/builder";
-import { McuProvider } from "./Mcu.context";
+import { MtbProvider } from "./Mtb.context";
 
 const mcuStyleId = "mcu-styles";
 const DEFAULT_COLOR_MATCH = false;
@@ -30,7 +30,7 @@ export function Mtb({
   customColors = DEFAULT_CUSTOM_COLORS,
   prefix = DEFAULT_PREFIX,
   children,
-}: McuConfig & {
+}: MtbConfig & {
   /** Content to render inside the themed scope. */
   children?: React.ReactNode;
 }) {
@@ -66,9 +66,9 @@ export function Mtb({
   );
 
   return (
-    <McuProvider {...config} styleId={mcuStyleId}>
+    <MtbProvider {...config} styleId={mcuStyleId}>
       {children}
-    </McuProvider>
+    </MtbProvider>
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,9 @@
 // the page never rendered.
 
 export { builder } from "./lib/builder";
-export type { McuConfig, ShadcnTheme, ShadcnVarName } from "./lib/builder";
+export type {
+  McuConfig,
+  MtbConfig,
+  ShadcnTheme,
+  ShadcnVarName,
+} from "./lib/builder";

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -75,8 +75,8 @@ const schemesMap = {
   content: SchemeContent,
 } satisfies Record<SchemeName, SchemeConstructor>;
 
-/** Configuration for the Material Color Utilities builder. */
-export type McuConfig = {
+/** Configuration for the Material Theme Builder. */
+export type MtbConfig = {
   /** Source color in hex format (e.g., "#6750A4") used to generate the color scheme */
   source: string;
   /** Color scheme variant. Default: "tonalSpot" */
@@ -116,6 +116,12 @@ export type McuConfig = {
    */
   prefix?: string;
 };
+
+/**
+ * @deprecated Renamed `MtbConfig` — same shape. This alias will be removed in
+ * the next major.
+ */
+export type McuConfig = MtbConfig;
 
 // ─── Constants ───────────────────────────────────────────────────────────
 
@@ -514,7 +520,7 @@ function buildTokenToPaletteMap(
  * ```
  */
 export function builder(
-  hexSource: McuConfig["source"],
+  hexSource: MtbConfig["source"],
   {
     scheme = DEFAULT_SCHEME,
     contrast = DEFAULT_CONTRAST,
@@ -526,7 +532,7 @@ export function builder(
     error,
     customColors: hexCustomColors = DEFAULT_CUSTOM_COLORS,
     prefix = DEFAULT_PREFIX,
-  }: Omit<McuConfig, "source"> = {},
+  }: Omit<MtbConfig, "source"> = {},
 ) {
   const sourceArgb = argbFromHex(hexSource);
   const sourceHct = Hct.fromInt(sourceArgb);

--- a/src/lib/recolorizeSvg.ts
+++ b/src/lib/recolorizeSvg.ts
@@ -6,7 +6,7 @@ import {
 import type { Color, Lab65 } from "culori";
 import { converter, differenceCiede2000, parseHex } from "culori";
 import { kebabCase } from "lodash-es";
-import type { useMcu } from "../Mcu.context";
+import type { useMtb } from "../Mtb.context";
 import { STANDARD_TONES } from "./builder";
 
 /**
@@ -90,7 +90,7 @@ function findClosestTone(targetTone: number) {
 }
 
 /**
- * Ultra-optimized SVG recoloring that consumes directly the palettes from the MCU Context.
+ * Ultra-optimized SVG recoloring that consumes directly the palettes from the Mtb context.
  * This version reuses pre-computed palettes for maximum performance and perfect synchronization.
  *
  * **Matching Algorithm:**
@@ -120,7 +120,7 @@ function findClosestTone(targetTone: number) {
  */
 export function recolorizeSvg(
   svgString: string,
-  palettes: ReturnType<typeof useMcu>["allPalettes"],
+  palettes: ReturnType<typeof useMtb>["allPalettes"],
   options: RecolorizeSvgOptions = {},
 ) {
   const { tolerance = 15.0 } = options;

--- a/src/react.ts
+++ b/src/react.ts
@@ -4,5 +4,5 @@
 // callable from a server component. See tsup.config.ts.
 
 export { ExportButton } from "./ExportButton";
-export { useMcu } from "./Mcu.context";
 export { Mcu, Mtb } from "./Mtb";
+export { useMcu, useMtb } from "./Mtb.context";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "tsup";
 // React surface -- and so that nothing on the root entry points at it:
 //
 //   dist/index.js   no directive -- `builder`, the package root
-//   dist/react.js   "use client" -- Mtb, useMcu, ExportButton
+//   dist/react.js   "use client" -- Mtb, useMtb, ExportButton
 //   dist/cli.js     the CLI
 //
 // The two are independent: `index.js` does not import `react.js`, which is


### PR DESCRIPTION
Follow-up to #166, which renamed the component but stopped there: the context module was still `Mcu.context.tsx`, the hook was still `useMcu`, the config type was still `McuConfig` — and the README still documented `<Mcu>`, the *deprecated alias*, as the way to use the package.

Same pattern as #166: new name, old name kept as a `@deprecated` alias. No breaking change.

## Renamed

| Before | After | Note |
| --- | --- | --- |
| `src/Mcu.context.tsx` | `src/Mtb.context.tsx` | `git mv`, history preserved |
| `McuProvider` | `MtbProvider` | internal — not exported from the barrel, so renamed outright |
| `McuContext` | `MtbContext` | idem |
| `useMcu` | `useMtb` | public — `useMcu` kept as a deprecated alias |
| `McuConfig` | `MtbConfig` | public — `McuConfig` kept as a deprecated alias |

## Other leftovers found and fixed

- **README** still showed `import { Mcu }` / `<Mcu>` and a `## useMcu` section — missed by #166
- `tsup.config.ts` comment listing the react bundle's exports
- "MCU Context" in the `recolorizeSvg` doc comment
- `MtbConfig`'s jsdoc said "Material Color Utilities builder" → "Material Theme Builder"
- the unreleased `mcu-renamed-mtb` changeset was widened to cover the hook and the type (edited in place rather than adding a second changeset, since it hasn't shipped)
- new test asserting `useMcu === useMtb`

## Deliberately left alone

The hook's returned fields (`mcuConfig`, `setMcuConfig`, `getMcuColor`) and the `mcu-styles` DOM id. Renaming those changes a shape consumers destructure and an id they may target in CSS — a bigger call than a file rename, worth its own PR if wanted.

## Verification

`pnpm lgtm` green (build, build-figma, lint, check-format, check-exports, typecheck, 55 tests).

Emitted types confirm both surfaces:

```
dist/index.d.ts: export { type McuConfig, type MtbConfig, ... }
dist/react.d.ts: export { ExportButton, Mcu, Mtb, useMcu, useMtb }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
