### PR TITLE
feat: finish the `Mcu` → `Mtb` rename in the context value

### DIFF
--- a/.changeset/mtb-context-keys.md
+++ b/.changeset/mtb-context-keys.md
@@ -1,0 +1,19 @@
+---
+"material-theme-builder": minor
+---
+
+Finish the `Mcu` → `Mtb` rename in the value `useMtb()` returns: `mcuConfig`,
+`setMcuConfig` and `getMcuColor` are now `mtbConfig`, `setMtbConfig` and
+`getMtbColor`.
+
+The `mcu*` keys stay on the context value as deprecated aliases holding the very
+same references as their `mtb*` counterparts, so existing destructuring keeps
+working until the next major.
+
+```diff
+- const { setMcuConfig, getMcuColor } = useMtb();
++ const { setMtbConfig, getMtbColor } = useMtb();
+```
+
+The `id` of the injected `<style>` tag stays `mcu-styles`, since user CSS and
+scripts may target it.

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ A hook is also provided:
 ```tsx
 import { useMtb } from "material-theme-builder/react";
 
-const { initials, setMcuConfig, getMcuColor } = useMtb();
+const { initials, setMtbConfig, getMtbColor } = useMtb();
 
 return (
-  <button onClick={() => setMcuConfig({ ...initials, source: "#FF5722" })}>
-    Change to {getMcuColor("primary", "light")}
+  <button onClick={() => setMtbConfig({ ...initials, source: "#FF5722" })}>
+    Change to {getMtbColor("primary", "light")}
   </button>
 );
 ```

--- a/src/Flowfield.stories.helpers.tsx
+++ b/src/Flowfield.stories.helpers.tsx
@@ -116,12 +116,12 @@ function ButtonPill({
 export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
   const {
     allPalettes,
-    mcuConfig,
-    setMcuConfig: _setMcuConfig,
+    mtbConfig,
+    setMtbConfig: _setMtbConfig,
     initials,
   } = useMtb();
 
-  const setMcuConfig = useDebounceCallback(_setMcuConfig, 50);
+  const setMtbConfig = useDebounceCallback(_setMtbConfig, 50);
 
   const pendingAddIndexRef = useRef<number | null>(null);
 
@@ -170,25 +170,25 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
               {
                 key: "primary",
                 label: "Primary",
-                color: mcuConfig.primary ?? initials.source,
+                color: mtbConfig.primary ?? initials.source,
               },
               {
                 key: "secondary",
                 label: "Secondary",
-                color: mcuConfig.secondary,
+                color: mtbConfig.secondary,
               },
-              { key: "tertiary", label: "Tertiary", color: mcuConfig.tertiary },
-              { key: "error", label: "Error", color: mcuConfig.error },
-              { key: "neutral", label: "Neutral", color: mcuConfig.neutral },
+              { key: "tertiary", label: "Tertiary", color: mtbConfig.tertiary },
+              { key: "error", label: "Error", color: mtbConfig.error },
+              { key: "neutral", label: "Neutral", color: mtbConfig.neutral },
               {
                 key: "neutralVariant",
                 label: "Neutral variant",
-                color: mcuConfig.neutralVariant,
+                color: mtbConfig.neutralVariant,
               },
             ] as const
           ).map(({ key, label, color }) => {
             const paletteKey = kebabCase(key);
-            const isInferred = mcuConfig[key] === undefined;
+            const isInferred = mtbConfig[key] === undefined;
             const inferredHex = isInferred
               ? hexFromArgb(allPalettes[paletteKey]?.keyColor.toInt() ?? 0)
               : undefined;
@@ -199,8 +199,8 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
                   <ButtonPill
                     color={color}
                     onChange={(hex) => {
-                      setMcuConfig({
-                        ...mcuConfig,
+                      setMtbConfig({
+                        ...mtbConfig,
                         [key]: hex,
                       });
                     }}
@@ -213,7 +213,7 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
                         variant="ghost"
                         size="icon-xs"
                         onClick={() =>
-                          setMcuConfig({ ...mcuConfig, [key]: undefined })
+                          setMtbConfig({ ...mtbConfig, [key]: undefined })
                         }
                         className="-ml-1"
                       >
@@ -234,17 +234,17 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
 
           <hr className="my-1 border-t border-outline-variant w-6 mx-auto" />
 
-          {(mcuConfig.customColors ?? []).map(({ name, hex }, i) => (
+          {(mtbConfig.customColors ?? []).map(({ name, hex }, i) => (
             <Tooltip key={name}>
               <TooltipTrigger asChild>
                 <ButtonPill
                   color={hex}
                   onChange={(newHex) => {
-                    const updated = (mcuConfig.customColors ?? []).map(
+                    const updated = (mtbConfig.customColors ?? []).map(
                       (c, j) => (j === i ? { ...c, hex: newHex } : c),
                     );
-                    setMcuConfig({
-                      ...mcuConfig,
+                    setMtbConfig({
+                      ...mtbConfig,
                       customColors: updated,
                     });
                   }}
@@ -256,10 +256,10 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
                     variant="ghost"
                     size="icon-xs"
                     onClick={() => {
-                      const updated = (mcuConfig.customColors ?? []).filter(
+                      const updated = (mtbConfig.customColors ?? []).filter(
                         (_, j) => j !== i,
                       );
-                      setMcuConfig({ ...mcuConfig, customColors: updated });
+                      setMtbConfig({ ...mtbConfig, customColors: updated });
                     }}
                     className="-ml-1"
                   >
@@ -280,7 +280,7 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
                   pendingAddIndexRef.current = null;
                 }}
                 onChange={(hex) => {
-                  const existing = mcuConfig.customColors ?? [];
+                  const existing = mtbConfig.customColors ?? [];
                   const idx = pendingAddIndexRef.current;
 
                   if (idx !== null && idx < existing.length) {
@@ -288,12 +288,12 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
                     const updated = existing.map((c, j) =>
                       j === idx ? { ...c, hex } : c,
                     );
-                    setMcuConfig({ ...mcuConfig, customColors: updated });
+                    setMtbConfig({ ...mtbConfig, customColors: updated });
                   } else {
                     // first change of this pick session — add a new color
                     pendingAddIndexRef.current = existing.length;
-                    setMcuConfig({
-                      ...mcuConfig,
+                    setMtbConfig({
+                      ...mtbConfig,
                       customColors: [
                         ...existing,
                         {
@@ -321,10 +321,10 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
               { label: "Med", value: 0.5 },
               { label: "Hi", value: 1 },
             ] as const;
-            const current = mcuConfig.contrast ?? 0;
+            const current = mtbConfig.contrast ?? 0;
             const idx = levels.findIndex((l) => l.value === current);
             const next = levels[(idx + 1) % levels.length] ?? levels[0];
-            setMcuConfig({ ...mcuConfig, contrast: next.value });
+            setMtbConfig({ ...mtbConfig, contrast: next.value });
           }}
         >
           {(
@@ -333,7 +333,7 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
               { label: "Med", value: 0.5 },
               { label: "Hi", value: 1 },
             ] as const
-          ).find((l) => l.value === (mcuConfig.contrast ?? 0))?.label ?? "Std"}
+          ).find((l) => l.value === (mtbConfig.contrast ?? 0))?.label ?? "Std"}
         </Button>
         <div>
           <ButtonGroup>
@@ -342,13 +342,13 @@ export function FlowfieldScene({ ...props }: ComponentProps<typeof Flowfield>) {
               variant="outline"
               className="capitalize"
               onClick={() => {
-                const currentScheme = mcuConfig.scheme ?? "tonalSpot";
+                const currentScheme = mtbConfig.scheme ?? "tonalSpot";
                 const idx = schemeNames.indexOf(currentScheme);
                 const next = schemeNames[(idx + 1) % schemeNames.length];
-                setMcuConfig({ ...mcuConfig, scheme: next });
+                setMtbConfig({ ...mtbConfig, scheme: next });
               }}
             >
-              {mcuConfig.scheme ?? "tonalSpot"}
+              {mtbConfig.scheme ?? "tonalSpot"}
             </Button>
           </ButtonGroup>
         </div>

--- a/src/Mtb.context.tsx
+++ b/src/Mtb.context.tsx
@@ -14,12 +14,28 @@ import { createRequiredContext } from "./lib/createRequiredContext";
 
 type Api = {
   initials: MtbConfig;
-  mcuConfig: MtbConfig;
-  setMcuConfig: (config: MtbConfig) => void;
-  getMcuColor: (colorName: TokenName, theme?: string) => string;
+  mtbConfig: MtbConfig;
+  setMtbConfig: (config: MtbConfig) => void;
+  getMtbColor: (colorName: TokenName, theme?: string) => string;
   allPalettes: Record<string, TonalPalette>;
   figmaTokens: FigmaTokens;
   figmaVariables: FigmaVariable[];
+
+  /**
+   * @deprecated Renamed `mtbConfig` — same value. This alias will be removed in
+   * the next major.
+   */
+  mcuConfig: MtbConfig;
+  /**
+   * @deprecated Renamed `setMtbConfig` — same setter. This alias will be
+   * removed in the next major.
+   */
+  setMcuConfig: (config: MtbConfig) => void;
+  /**
+   * @deprecated Renamed `getMtbColor` — same function. This alias will be
+   * removed in the next major.
+   */
+  getMcuColor: (colorName: TokenName, theme?: string) => string;
 };
 
 const [useMtb, Provider, MtbContext] = createRequiredContext<Api>();
@@ -40,13 +56,13 @@ export const MtbProvider = ({
   const [initials] = useState(() => configProps);
   // console.log("MtbProvider initials", initials);
 
-  const [mcuConfig, setMcuConfig] = useState(initials);
+  const [mtbConfig, setMtbConfig] = useState(initials);
 
-  // Update mcuConfig when configProps change
+  // Update mtbConfig when configProps change
   // Use a stable key to detect when config values have changed
   const configKey = JSON.stringify(configProps);
   React.useEffect(() => {
-    setMcuConfig(configProps);
+    setMtbConfig(configProps);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [configKey]);
 
@@ -59,8 +75,8 @@ export const MtbProvider = ({
     figmaVariables,
   } = useMemo(() => {
     const { toCss, toFigmaTokens, toFigmaVariables, ...rest } = builder(
-      mcuConfig.source,
-      mcuConfig,
+      mtbConfig.source,
+      mtbConfig,
     );
     return {
       css: toCss(),
@@ -68,21 +84,21 @@ export const MtbProvider = ({
       figmaVariables: toFigmaVariables(),
       ...rest,
     };
-  }, [mcuConfig]);
+  }, [mtbConfig]);
 
   //
-  // getMcuColor
+  // getMtbColor
   //
 
-  const getMcuColor = useCallback(
+  const getMtbColor = useCallback(
     (colorName: TokenName, theme: string | undefined) => {
-      // console.log("getMcuColor", colorName, theme);
+      // console.log("getMtbColor", colorName, theme);
       const mergedColors =
         theme === "light" ? mergedColorsLight : mergedColorsDark;
       const colorValue = mergedColors[colorName];
 
       if (colorValue === undefined) {
-        throw new Error(`Unknown MCU token '${colorName}'`);
+        throw new Error(`Unknown token '${colorName}'`);
       }
 
       return hexFromArgb(colorValue);
@@ -98,17 +114,22 @@ export const MtbProvider = ({
     () =>
       ({
         initials,
-        mcuConfig,
-        setMcuConfig,
-        getMcuColor,
+        mtbConfig,
+        setMtbConfig,
+        getMtbColor,
         allPalettes,
         figmaTokens,
         figmaVariables,
+
+        // deprecated aliases
+        mcuConfig: mtbConfig,
+        setMcuConfig: setMtbConfig,
+        getMcuColor: getMtbColor,
       }) satisfies Api,
     [
-      getMcuColor,
+      getMtbColor,
       initials,
-      mcuConfig,
+      mtbConfig,
       allPalettes,
       figmaTokens,
       figmaVariables,
@@ -122,7 +143,7 @@ export const MtbProvider = ({
   // browser, so a server-rendered page would ship with none of the variables
   // defined and paint before hydration filled them in -- every color missing
   // for that first frame. Rendering the tag puts the CSS in the HTML the
-  // server sends, and React updates its content in place when `setMcuConfig`
+  // server sends, and React updates its content in place when `setMtbConfig`
   // changes the theme.
   //
   // Not `<style href precedence>`: React treats hoisted stylesheets as

--- a/src/Mtb.test.tsx
+++ b/src/Mtb.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render } from "@testing-library/react";
+import { useEffect } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it } from "vitest";
 import { Mcu, Mtb } from "./Mtb";
@@ -135,5 +136,27 @@ describe("Mtb", () => {
 
   it("should keep `useMcu` as a deprecated alias of `useMtb`", () => {
     expect(useMcu).toBe(useMtb);
+  });
+
+  it("should expose the `mcu*` context keys as deprecated aliases of the `mtb*` ones", () => {
+    let api: ReturnType<typeof useMtb> | undefined;
+
+    function Probe() {
+      const value = useMtb();
+      useEffect(() => {
+        api = value;
+      }, [value]);
+      return null;
+    }
+
+    render(
+      <Mtb source="#6750A4">
+        <Probe />
+      </Mtb>,
+    );
+
+    expect(api?.mcuConfig).toBe(api?.mtbConfig);
+    expect(api?.setMcuConfig).toBe(api?.setMtbConfig);
+    expect(api?.getMcuColor).toBe(api?.getMtbColor);
   });
 });

--- a/src/Mtb.tsx
+++ b/src/Mtb.tsx
@@ -10,7 +10,9 @@ import {
 } from "./lib/builder";
 import { MtbProvider } from "./Mtb.context";
 
-const mcuStyleId = "mcu-styles";
+// The DOM id stays `mcu-styles`: it is observable from user CSS/JS, so renaming
+// it would break selectors silently. Only the local binding follows the rename.
+const styleId = "mcu-styles";
 const DEFAULT_COLOR_MATCH = false;
 
 /**
@@ -66,7 +68,7 @@ export function Mtb({
   );
 
   return (
-    <MtbProvider {...config} styleId={mcuStyleId}>
+    <MtbProvider {...config} styleId={styleId}>
       {children}
     </MtbProvider>
   );


### PR DESCRIPTION
The `Mcu` → `Mtb` rename (#166, #169) covered the component, the hook and the config type, but left the shape of the value `useMtb()` returns untouched: it still handed back `mcuConfig`, `setMcuConfig` and `getMcuColor` — so the documented `useMtb` example in the README read `const { setMcuConfig, getMcuColor } = useMtb()`.

## Changes

- `src/Mtb.context.tsx` — `mcuConfig` / `setMcuConfig` / `getMcuColor` are now `mtbConfig` / `setMtbConfig` / `getMtbColor`. The `mcu*` keys stay on the context value as `@deprecated` aliases holding the very same references, so existing destructuring keeps working until the next major. The `Unknown MCU token` error message drops the acronym.
- `src/Flowfield.stories.helpers.tsx` — the ~30 call sites follow.
- `README.md` — the `useMtb` example uses the new names.
- `src/Mtb.tsx` — the local `mcuStyleId` binding becomes `styleId`.

## What deliberately keeps the old name

- The exported `Mcu` / `useMcu` / `McuConfig` aliases, as introduced in #166 and #169.
- **The `id` of the injected `<style>` tag stays `mcu-styles`.** It is observable from user CSS and scripts, so renaming it would break selectors silently — a comment in `Mtb.tsx` records why.

## Tests

New test asserting each `mcu*` context key is the same reference as its `mtb*` counterpart. Full `pnpm run lgtm` green (111 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dap13K3ck1Xjt5m5i7VNAu
