### PR TITLE
feat(figma): export the shadcn remap as its own token group

### DIFF
--- a/.changeset/figma-shadcn-group.md
+++ b/.changeset/figma-shadcn-group.md
@@ -1,0 +1,20 @@
+---
+"material-theme-builder": minor
+---
+
+`toFigmaTokens()` now emits a `shadcn` group alongside `ref` and `sys`, and
+`toFigmaVariables()` the matching `shadcn/*` descriptors. Designers get the 31
+names they actually build components from — `Card`, `Muted`, `Chart 1` — where
+before the export stopped at the M3 roles and left the remap behind in the CSS.
+
+It reads `SHADCN_MAPPING`, so it is the third exporter on that table next to
+`toShadcn()` and `toTailwind({ shadcn: true })` rather than a second opinion
+about which M3 role backs which variable. Each token is a DTCG alias onto its
+`sys/color` token (`{sys.color.Surface Container Low}`), identical in both mode
+files: the sys token carries the mode, so the group follows a reseed and a mode
+switch the way `var(--md-sys-color-*)` does. `css.variable` spells the shadcn
+variable — unprefixed, since `prefix` renames the M3 layer and not the fixed set
+shadcn components read.
+
+The Figma plugin needs no change: it already creates every variable before
+resolving aliases, so `shadcn/Card` lands as a real alias in the same collection.

--- a/README.md
+++ b/README.md
@@ -436,6 +436,17 @@ Simply override/remap
 > Make sure `:root, .dark { ... }` comes AFTER `.root { ... } .dark { ... }` to
 > take precedence.
 
+The same remap ships to designers: `toFigmaTokens()` (and `--format figma`) emits
+a `shadcn` group next to `ref` and `sys`, so a Figma file carries `Card`, `Muted`,
+`Chart 1` — the names components are built from — and not only the M3 roles. Each
+is an alias onto its `sys/color` token rather than a copy of its value, so it
+follows the mode and the seed exactly as `var(--md-sys-color-*)` does above, and
+`css.variable` on each token spells out the CSS variable it stands for.
+
+Worth knowing if you ever map a frame by hand instead: `sys/color/Background` is
+the M3 role, and shadcn's `--background` is **not** it — that one is `surface`.
+The `shadcn` group exists so nobody has to remember which.
+
 # Dev
 
 ## INSTALL

--- a/src/fixtures/theme/Dark.tokens.json
+++ b/src/fixtures/theme/Dark.tokens.json
@@ -1,4 +1,7 @@
 {
+  "$extensions": {
+    "com.figma.modeName": "Dark"
+  },
   "ref": {
     "palette": {
       "Primary": {
@@ -2846,7 +2849,285 @@
       }
     }
   },
-  "$extensions": {
-    "com.figma.modeName": "Dark"
+  "shadcn": {
+    "Background": {
+      "$type": "color",
+      "$value": "{sys.color.Surface}",
+      "$description": "shadcn --background, backed by the M3 surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--background"
+      }
+    },
+    "Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface}",
+      "$description": "shadcn --foreground, backed by the M3 on-surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--foreground"
+      }
+    },
+    "Card": {
+      "$type": "color",
+      "$value": "{sys.color.Surface Container Low}",
+      "$description": "shadcn --card, backed by the M3 surface-container-low role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--card"
+      }
+    },
+    "Card Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface}",
+      "$description": "shadcn --card-foreground, backed by the M3 on-surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--card-foreground"
+      }
+    },
+    "Popover": {
+      "$type": "color",
+      "$value": "{sys.color.Surface Container High}",
+      "$description": "shadcn --popover, backed by the M3 surface-container-high role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--popover"
+      }
+    },
+    "Popover Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface}",
+      "$description": "shadcn --popover-foreground, backed by the M3 on-surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--popover-foreground"
+      }
+    },
+    "Primary": {
+      "$type": "color",
+      "$value": "{sys.color.Primary}",
+      "$description": "shadcn --primary, backed by the M3 primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--primary"
+      }
+    },
+    "Primary Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Primary}",
+      "$description": "shadcn --primary-foreground, backed by the M3 on-primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--primary-foreground"
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Container}",
+      "$description": "shadcn --secondary, backed by the M3 secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--secondary"
+      }
+    },
+    "Secondary Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Secondary Container}",
+      "$description": "shadcn --secondary-foreground, backed by the M3 on-secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--secondary-foreground"
+      }
+    },
+    "Muted": {
+      "$type": "color",
+      "$value": "{sys.color.Surface Container Highest}",
+      "$description": "shadcn --muted, backed by the M3 surface-container-highest role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--muted"
+      }
+    },
+    "Muted Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface Variant}",
+      "$description": "shadcn --muted-foreground, backed by the M3 on-surface-variant role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--muted-foreground"
+      }
+    },
+    "Accent": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Container}",
+      "$description": "shadcn --accent, backed by the M3 secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--accent"
+      }
+    },
+    "Accent Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Secondary Container}",
+      "$description": "shadcn --accent-foreground, backed by the M3 on-secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--accent-foreground"
+      }
+    },
+    "Destructive": {
+      "$type": "color",
+      "$value": "{sys.color.Error}",
+      "$description": "shadcn --destructive, backed by the M3 error role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--destructive"
+      }
+    },
+    "Border": {
+      "$type": "color",
+      "$value": "{sys.color.Outline Variant}",
+      "$description": "shadcn --border, backed by the M3 outline-variant role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--border"
+      }
+    },
+    "Input": {
+      "$type": "color",
+      "$value": "{sys.color.Outline}",
+      "$description": "shadcn --input, backed by the M3 outline role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--input"
+      }
+    },
+    "Ring": {
+      "$type": "color",
+      "$value": "{sys.color.Primary}",
+      "$description": "shadcn --ring, backed by the M3 primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--ring"
+      }
+    },
+    "Chart 1": {
+      "$type": "color",
+      "$value": "{sys.color.Primary Fixed}",
+      "$description": "shadcn --chart-1, backed by the M3 primary-fixed role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-1"
+      }
+    },
+    "Chart 2": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Fixed}",
+      "$description": "shadcn --chart-2, backed by the M3 secondary-fixed role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-2"
+      }
+    },
+    "Chart 3": {
+      "$type": "color",
+      "$value": "{sys.color.Tertiary Fixed}",
+      "$description": "shadcn --chart-3, backed by the M3 tertiary-fixed role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-3"
+      }
+    },
+    "Chart 4": {
+      "$type": "color",
+      "$value": "{sys.color.Primary Fixed Dim}",
+      "$description": "shadcn --chart-4, backed by the M3 primary-fixed-dim role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-4"
+      }
+    },
+    "Chart 5": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Fixed Dim}",
+      "$description": "shadcn --chart-5, backed by the M3 secondary-fixed-dim role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-5"
+      }
+    },
+    "Sidebar": {
+      "$type": "color",
+      "$value": "{sys.color.Surface Container Low}",
+      "$description": "shadcn --sidebar, backed by the M3 surface-container-low role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar"
+      }
+    },
+    "Sidebar Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface}",
+      "$description": "shadcn --sidebar-foreground, backed by the M3 on-surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-foreground"
+      }
+    },
+    "Sidebar Primary": {
+      "$type": "color",
+      "$value": "{sys.color.Primary}",
+      "$description": "shadcn --sidebar-primary, backed by the M3 primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-primary"
+      }
+    },
+    "Sidebar Primary Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Primary}",
+      "$description": "shadcn --sidebar-primary-foreground, backed by the M3 on-primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-primary-foreground"
+      }
+    },
+    "Sidebar Accent": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Container}",
+      "$description": "shadcn --sidebar-accent, backed by the M3 secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-accent"
+      }
+    },
+    "Sidebar Accent Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Secondary Container}",
+      "$description": "shadcn --sidebar-accent-foreground, backed by the M3 on-secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-accent-foreground"
+      }
+    },
+    "Sidebar Border": {
+      "$type": "color",
+      "$value": "{sys.color.Outline Variant}",
+      "$description": "shadcn --sidebar-border, backed by the M3 outline-variant role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-border"
+      }
+    },
+    "Sidebar Ring": {
+      "$type": "color",
+      "$value": "{sys.color.Primary}",
+      "$description": "shadcn --sidebar-ring, backed by the M3 primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-ring"
+      }
+    }
   }
 }

--- a/src/fixtures/theme/Light.tokens.json
+++ b/src/fixtures/theme/Light.tokens.json
@@ -1,4 +1,7 @@
 {
+  "$extensions": {
+    "com.figma.modeName": "Light"
+  },
   "ref": {
     "palette": {
       "Primary": {
@@ -2846,7 +2849,285 @@
       }
     }
   },
-  "$extensions": {
-    "com.figma.modeName": "Light"
+  "shadcn": {
+    "Background": {
+      "$type": "color",
+      "$value": "{sys.color.Surface}",
+      "$description": "shadcn --background, backed by the M3 surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--background"
+      }
+    },
+    "Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface}",
+      "$description": "shadcn --foreground, backed by the M3 on-surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--foreground"
+      }
+    },
+    "Card": {
+      "$type": "color",
+      "$value": "{sys.color.Surface Container Low}",
+      "$description": "shadcn --card, backed by the M3 surface-container-low role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--card"
+      }
+    },
+    "Card Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface}",
+      "$description": "shadcn --card-foreground, backed by the M3 on-surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--card-foreground"
+      }
+    },
+    "Popover": {
+      "$type": "color",
+      "$value": "{sys.color.Surface Container High}",
+      "$description": "shadcn --popover, backed by the M3 surface-container-high role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--popover"
+      }
+    },
+    "Popover Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface}",
+      "$description": "shadcn --popover-foreground, backed by the M3 on-surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--popover-foreground"
+      }
+    },
+    "Primary": {
+      "$type": "color",
+      "$value": "{sys.color.Primary}",
+      "$description": "shadcn --primary, backed by the M3 primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--primary"
+      }
+    },
+    "Primary Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Primary}",
+      "$description": "shadcn --primary-foreground, backed by the M3 on-primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--primary-foreground"
+      }
+    },
+    "Secondary": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Container}",
+      "$description": "shadcn --secondary, backed by the M3 secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--secondary"
+      }
+    },
+    "Secondary Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Secondary Container}",
+      "$description": "shadcn --secondary-foreground, backed by the M3 on-secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--secondary-foreground"
+      }
+    },
+    "Muted": {
+      "$type": "color",
+      "$value": "{sys.color.Surface Container Highest}",
+      "$description": "shadcn --muted, backed by the M3 surface-container-highest role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--muted"
+      }
+    },
+    "Muted Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface Variant}",
+      "$description": "shadcn --muted-foreground, backed by the M3 on-surface-variant role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--muted-foreground"
+      }
+    },
+    "Accent": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Container}",
+      "$description": "shadcn --accent, backed by the M3 secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--accent"
+      }
+    },
+    "Accent Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Secondary Container}",
+      "$description": "shadcn --accent-foreground, backed by the M3 on-secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--accent-foreground"
+      }
+    },
+    "Destructive": {
+      "$type": "color",
+      "$value": "{sys.color.Error}",
+      "$description": "shadcn --destructive, backed by the M3 error role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--destructive"
+      }
+    },
+    "Border": {
+      "$type": "color",
+      "$value": "{sys.color.Outline Variant}",
+      "$description": "shadcn --border, backed by the M3 outline-variant role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--border"
+      }
+    },
+    "Input": {
+      "$type": "color",
+      "$value": "{sys.color.Outline}",
+      "$description": "shadcn --input, backed by the M3 outline role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--input"
+      }
+    },
+    "Ring": {
+      "$type": "color",
+      "$value": "{sys.color.Primary}",
+      "$description": "shadcn --ring, backed by the M3 primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--ring"
+      }
+    },
+    "Chart 1": {
+      "$type": "color",
+      "$value": "{sys.color.Primary Fixed}",
+      "$description": "shadcn --chart-1, backed by the M3 primary-fixed role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-1"
+      }
+    },
+    "Chart 2": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Fixed}",
+      "$description": "shadcn --chart-2, backed by the M3 secondary-fixed role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-2"
+      }
+    },
+    "Chart 3": {
+      "$type": "color",
+      "$value": "{sys.color.Tertiary Fixed}",
+      "$description": "shadcn --chart-3, backed by the M3 tertiary-fixed role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-3"
+      }
+    },
+    "Chart 4": {
+      "$type": "color",
+      "$value": "{sys.color.Primary Fixed Dim}",
+      "$description": "shadcn --chart-4, backed by the M3 primary-fixed-dim role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-4"
+      }
+    },
+    "Chart 5": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Fixed Dim}",
+      "$description": "shadcn --chart-5, backed by the M3 secondary-fixed-dim role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--chart-5"
+      }
+    },
+    "Sidebar": {
+      "$type": "color",
+      "$value": "{sys.color.Surface Container Low}",
+      "$description": "shadcn --sidebar, backed by the M3 surface-container-low role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar"
+      }
+    },
+    "Sidebar Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Surface}",
+      "$description": "shadcn --sidebar-foreground, backed by the M3 on-surface role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-foreground"
+      }
+    },
+    "Sidebar Primary": {
+      "$type": "color",
+      "$value": "{sys.color.Primary}",
+      "$description": "shadcn --sidebar-primary, backed by the M3 primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-primary"
+      }
+    },
+    "Sidebar Primary Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Primary}",
+      "$description": "shadcn --sidebar-primary-foreground, backed by the M3 on-primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-primary-foreground"
+      }
+    },
+    "Sidebar Accent": {
+      "$type": "color",
+      "$value": "{sys.color.Secondary Container}",
+      "$description": "shadcn --sidebar-accent, backed by the M3 secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-accent"
+      }
+    },
+    "Sidebar Accent Foreground": {
+      "$type": "color",
+      "$value": "{sys.color.On Secondary Container}",
+      "$description": "shadcn --sidebar-accent-foreground, backed by the M3 on-secondary-container role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-accent-foreground"
+      }
+    },
+    "Sidebar Border": {
+      "$type": "color",
+      "$value": "{sys.color.Outline Variant}",
+      "$description": "shadcn --sidebar-border, backed by the M3 outline-variant role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-border"
+      }
+    },
+    "Sidebar Ring": {
+      "$type": "color",
+      "$value": "{sys.color.Primary}",
+      "$description": "shadcn --sidebar-ring, backed by the M3 primary role.",
+      "$extensions": {
+        "com.figma.scopes": ["ALL_SCOPES"],
+        "css.variable": "--sidebar-ring"
+      }
+    }
   }
 }

--- a/src/fixtures/theme/README.md
+++ b/src/fixtures/theme/README.md
@@ -4,5 +4,5 @@ Regenerate with:
 
 ```sh
 pnpm run build
-node dist/cli.js builder "#6750A4" --output src/fixtures/theme
+node dist/cli.js "#6750A4" --format figma --output src/fixtures/theme
 ```

--- a/src/lib/builder.figma.test.ts
+++ b/src/lib/builder.figma.test.ts
@@ -12,6 +12,7 @@ import type {
   FigmaVariableValue,
 } from "./builder";
 import { builder, STANDARD_TONES } from "./builder";
+import { SHADCN_MAPPING } from "./builder.shadcn";
 
 function isDtcgColorValue(v: string | DtcgColorValue): v is DtcgColorValue {
   return typeof v !== "string";
@@ -101,6 +102,36 @@ describe("builder › toFigmaVariables()", () => {
     const refVars = variables.filter((v) => v.path.startsWith("ref/palette/"));
 
     for (const v of refVars) {
+      expect(v.values["Light"]).toEqual(v.values["Dark"]);
+    }
+  });
+
+  it("should alias every shadcn variable onto a sys color variable it defines", () => {
+    const variables = builder("#6750A4").toFigmaVariables();
+    const paths = new Set(variables.map((v) => v.path));
+    const shadcnVars = variables.filter((v) => v.path.startsWith("shadcn/"));
+
+    expect(shadcnVars).toHaveLength(SHADCN_MAPPING.length);
+
+    for (const v of shadcnVars) {
+      for (const mode of ["Light", "Dark"] as const) {
+        const value = v.values[mode];
+        expect(value).toBeDefined();
+        if (!value || !isAlias(value))
+          throw new Error(`${v.path} is not an alias in ${mode}`);
+
+        // A dangling alias is a variable Figma silently paints black.
+        expect(value.alias).toMatch(/^sys\/color\/.+$/);
+        expect(paths.has(value.alias)).toBe(true);
+      }
+    }
+  });
+
+  it("should point both modes of a shadcn variable at the same sys variable", () => {
+    // The mode lives in the sys token, not here — same reference, read twice.
+    const variables = builder("#6750A4").toFigmaVariables();
+
+    for (const v of variables.filter((v) => v.path.startsWith("shadcn/"))) {
       expect(v.values["Light"]).toEqual(v.values["Dark"]);
     }
   });
@@ -325,6 +356,66 @@ describe("builder › toFigmaTokens()", () => {
       expect(file.sys.color).toHaveProperty("Brand Container");
       expect(file.sys.color).toHaveProperty("On Brand Container");
     }
+  });
+
+  it("should mirror the shadcn remap in a shadcn group", () => {
+    // Derived from SHADCN_MAPPING rather than spelled out: that the mapping is
+    // the full shadcn variable set is builder.shadcn.test.ts's assertion, and
+    // this one is about the Figma export covering whatever the mapping holds.
+    const result = builder("#6750A4").toFigmaTokens();
+
+    for (const key of ["Light.tokens.json", "Dark.tokens.json"] as const) {
+      const { shadcn, sys } = result[key];
+
+      expect(Object.keys(shadcn)).toHaveLength(SHADCN_MAPPING.length);
+
+      for (const [cssVar] of SHADCN_MAPPING) {
+        const token = Object.values(shadcn).find(
+          (t) => t.$extensions["css.variable"] === cssVar,
+        );
+        expect(token, `no shadcn token for ${cssVar}`).toBeDefined();
+        if (!token) continue;
+
+        // An alias into sys, and one that resolves: `{sys.color.Card}` would
+        // import as a broken reference, not as an error.
+        expect(token.$type).toBe("color");
+        expect(token.$value).toMatch(/^\{sys\.color\..+\}$/);
+        const target = String(token.$value).slice("{sys.color.".length, -1);
+        expect(Object.keys(sys.color)).toContain(target);
+      }
+    }
+  });
+
+  it("should give shadcn tokens Title Case names", () => {
+    const { shadcn } = builder("#6750A4").toFigmaTokens()["Light.tokens.json"];
+
+    expect(shadcn).toHaveProperty("Card");
+    expect(shadcn).toHaveProperty("Muted Foreground");
+    expect(shadcn).toHaveProperty("Chart 1");
+    expect(shadcn).toHaveProperty("Sidebar Accent Foreground");
+  });
+
+  it("should keep shadcn tokens identical in both mode files", () => {
+    // Both files carry the same alias; the sys token it points at is what
+    // differs per mode.
+    const result = builder("#6750A4").toFigmaTokens();
+
+    expect(result["Light.tokens.json"].shadcn).toEqual(
+      result["Dark.tokens.json"].shadcn,
+    );
+  });
+
+  it("should leave shadcn variable names unprefixed", () => {
+    // `prefix` renames the M3 layer; shadcn's variable set is fixed, so a
+    // `--brand-card` would name a variable no shadcn component reads.
+    const { sys, shadcn } = builder("#6750A4", {
+      prefix: "brand",
+    }).toFigmaTokens()["Light.tokens.json"];
+
+    expect(sys.color["Primary"]?.$extensions["css.variable"]).toBe(
+      "--brand-sys-color-primary",
+    );
+    expect(shadcn["Card"]?.$extensions["css.variable"]).toBe("--card");
   });
 
   it("should contain com.figma.modeName in each mode file", () => {

--- a/src/lib/builder.figma.ts
+++ b/src/lib/builder.figma.ts
@@ -13,6 +13,7 @@ import {
   STANDARD_TONES,
   tokenDescriptions,
 } from "./builder";
+import { SHADCN_MAPPING } from "./builder.shadcn";
 
 // ─── Figma token types ───────────────────────────────────────────────────
 
@@ -44,6 +45,7 @@ export type FigmaTokenModeFile = {
   sys: {
     color: Record<string, DtcgColorToken>;
   };
+  shadcn: Record<string, DtcgColorToken>;
 };
 
 /** Return type of builder().toFigmaTokens() */
@@ -86,6 +88,7 @@ export function buildFigmaVariables(ctx: BuilderContext) {
   // Figma Variables compatible format using M3 token architecture:
   //   ref/palette/* — Reference Tokens (Tier 1): raw tonal palette values
   //   sys/color/*   — System Tokens (Tier 2): semantic roles referencing palette tones
+  //   shadcn/*      — the shadcn remap, referencing sys roles
   //
   // see: https://m3.material.io/foundations/design-tokens/overview
 
@@ -178,6 +181,38 @@ export function buildFigmaVariables(ctx: BuilderContext) {
     });
   }
 
+  // ── shadcn/* — aliases onto sys/color/*, one alias for both modes ──
+  //
+  // The third reader of SHADCN_MAPPING, next to `toShadcn()` and
+  // `toTailwind({ shadcn: true })`. Designers lay out shadcn components in
+  // Figma with the same vocabulary developers write — `Card`, `Muted`,
+  // `Chart 1` — and because all three exports read the one table, a name
+  // cannot mean one M3 role in Figma and another in the CSS.
+  //
+  // Aliases rather than values, and the *same* alias in both modes: the sys
+  // token they point at is what carries the mode, exactly as
+  // `--card: var(--md-sys-color-surface-container-low)` does in the remap.
+  // Dark is not a second set of colors here, it is the same reference read
+  // under a second mode.
+
+  const sysPaths = new Set(variables.map((v) => v.path));
+
+  for (const [cssVar, m3Token] of SHADCN_MAPPING) {
+    const alias = `sys/color/${startCase(m3Token)}`;
+    if (!sysPaths.has(alias)) {
+      throw new Error(
+        `M3 token '${m3Token}' is missing from the scheme, needed by '${cssVar}'. This is likely a bug in the implementation.`,
+      );
+    }
+
+    variables.push({
+      path: `shadcn/${startCase(cssVar.slice(2))}`,
+      description: `shadcn ${cssVar}, backed by the M3 ${m3Token} role.`,
+      scopes: ["ALL_SCOPES"],
+      values: { Light: { alias }, Dark: { alias } },
+    });
+  }
+
   return variables;
 }
 
@@ -224,6 +259,16 @@ export function buildFigmaTokens(ctx: BuilderContext) {
     const lastSegment = v.path.split("/").at(-1);
     if (!lastSegment) return { "com.figma.scopes": v.scopes ?? ["ALL_SCOPES"] };
     const tokenName = kebabCase(lastSegment);
+
+    // shadcn's variable names are fixed and unprefixed — `prefix` renames the
+    // M3 layer, not the vocabulary M3 is remapped onto. `Chart 1` → `--chart-1`.
+    if (v.path.startsWith("shadcn/")) {
+      return {
+        "com.figma.scopes": v.scopes ?? ["ALL_SCOPES"],
+        "css.variable": `--${tokenName}`,
+      };
+    }
+
     return {
       "com.figma.scopes": v.scopes ?? ["ALL_SCOPES"],
       "css.variable": `--${prefix}-sys-color-${tokenName}`,
@@ -251,12 +296,16 @@ export function buildFigmaTokens(ctx: BuilderContext) {
     if (parts[0] === "sys" && parts[1] === "color" && parts[2]) {
       return { kind: "color" as const, tokenName: parts[2] };
     }
+    if (parts[0] === "shadcn" && parts[1]) {
+      return { kind: "shadcn" as const, tokenName: parts[1] };
+    }
     return null;
   }
 
   function buildModeFile(modeName: string) {
     const palette: Record<string, DtcgPaletteGroup> = {};
     const color: Record<string, DtcgColorToken> = {};
+    const shadcn: Record<string, DtcgColorToken> = {};
 
     for (const v of variables) {
       const modeValue = v.values[modeName];
@@ -268,6 +317,8 @@ export function buildFigmaTokens(ctx: BuilderContext) {
       if (parsed.kind === "palette") {
         const group = (palette[parsed.paletteName] ??= {});
         group[parsed.tone] = buildToken(v, modeValue);
+      } else if (parsed.kind === "shadcn") {
+        shadcn[parsed.tokenName] = buildToken(v, modeValue);
       } else {
         color[parsed.tokenName] = buildToken(v, modeValue);
       }
@@ -277,6 +328,7 @@ export function buildFigmaTokens(ctx: BuilderContext) {
       $extensions: { "com.figma.modeName": modeName },
       ref: { palette },
       sys: { color },
+      shadcn,
     };
   }
 


### PR DESCRIPTION
## Why

The Figma export carries the M3 layer and stops there — 168 tones, 49 roles. None of the 31 names a designer actually lays out a shadcn component with (`Card`, `Muted`, `Chart 1`, `Sidebar Accent Foreground`) reaches Figma, even though `SHADCN_MAPPING` has said which M3 role backs each of them all along. Designers and developers end up describing the same UI in two vocabularies.

The near-miss that motivated it: `sys/color/Background` is *not* shadcn's `--background`. That one is `surface`. A designer mapping the export onto a shadcn frame by hand gets it wrong, and nothing complains.

## What

`toFigmaTokens()` emits a `shadcn` group beside `ref` and `sys`; `toFigmaVariables()` emits the matching `shadcn/*` descriptors.

```jsonc
"shadcn": {
  "Card": {
    "$type": "color",
    "$value": "{sys.color.Surface Container Low}",
    "$description": "shadcn --card, backed by the M3 surface-container-low role.",
    "$extensions": { "com.figma.scopes": ["ALL_SCOPES"], "css.variable": "--card" }
  }
}
```

- **Reads `SHADCN_MAPPING`**, so it is the third exporter on that table next to `toShadcn()` and `toTailwind({ shadcn: true })` — not a second opinion about which role backs which variable. A row added there shows up in Figma for free; a row naming a token the scheme lacks throws, as it does in `buildShadcn`.
- **Aliases, not values**, and the *same* alias in both mode files. The sys token carries the mode, so the group follows a mode switch and a reseed exactly as `var(--md-sys-color-*)` does in the CSS remap.
- **`css.variable` stays unprefixed.** `--prefix` renames the M3 layer; shadcn's variable set is fixed, and a `--brand-card` would name something no component reads.

## Notes

- **No plugin change.** `syncVariables` already creates every variable before resolving aliases, so `shadcn/Card` lands as a real Figma alias in the same collection.
- Fixtures regenerated (`src/fixtures/theme/*`), and their README's regenerate command fixed — it passed `builder` as the source color.
- 6 new tests: mapping coverage, alias targets resolve, both modes identical, Title Case names, unprefixed under `--prefix`. The existing DTCG schema validation covers the new group and passes.
- `pnpm run lgtm` green (117 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmZpQG8qwLrA7V7RpKySJR
