### PR TITLE
feat: Tailwind v4 plugin, and the shadcn remap as a stylesheet

### DIFF
--- a/.changeset/tidy-pans-attack.md
+++ b/.changeset/tidy-pans-attack.md
@@ -1,0 +1,24 @@
+---
+"material-theme-builder": minor
+---
+
+Add a Tailwind v4 plugin, `material-theme-builder/tailwind`, replacing the
+hand-written `@theme inline` block:
+
+```css
+@import "tailwindcss";
+@plugin "material-theme-builder/tailwind" {
+  custom-colors: myCustomColor1, myCustomColor2;
+}
+```
+
+Custom colors — the part the stylesheet could never cover, since their names
+are only known to the app — register their four M3 roles and their shades on
+their own. `prefix` and `shades` options too.
+
+Also ships the shadcn remapping as a stylesheet of its own,
+`material-theme-builder/shadcn.css`, so the `:root, .dark { … }` block no
+longer has to be copied into a project.
+
+`material-theme-builder/tailwind.css` keeps working, and gains the two roles it
+was missing: `--color-surface-tint` and `--color-surface-variant`.

--- a/.changeset/tidy-pans-attack.md
+++ b/.changeset/tidy-pans-attack.md
@@ -2,8 +2,8 @@
 "material-theme-builder": minor
 ---
 
-Add a Tailwind v4 plugin, `material-theme-builder/tailwind`, replacing the
-hand-written `@theme inline` block:
+Add a Tailwind v4 plugin, `material-theme-builder/tailwind`, as an alternative
+to pasting the `@theme inline` block:
 
 ```css
 @import "tailwindcss";
@@ -18,7 +18,12 @@ their own. `prefix` and `shades` options too.
 
 Also ships the shadcn remapping as a stylesheet of its own,
 `material-theme-builder/shadcn.css`, so the `:root, .dark { … }` block no
-longer has to be copied into a project.
+longer has to be copied into a project. It stays CSS on purpose: it has to beat
+shadcn's own unlayered `:root`, which a plugin — confined to `@layer base` —
+cannot. Its selectors are doubled (`:root:root, .dark.dark`) so it wins by
+specificity rather than by source order, an `@import` being at the mercy of
+whatever the bundler does with it.
 
-`material-theme-builder/tailwind.css` keeps working, and gains the two roles it
-was missing: `--color-surface-tint` and `--color-surface-variant`.
+Nothing is removed. `material-theme-builder/tailwind.css` keeps working, and
+gains the two roles it was missing: `--color-surface-tint` and
+`--color-surface-variant`.

--- a/README.md
+++ b/README.md
@@ -219,12 +219,6 @@ Or simply, the same theme as a stylesheet:
 @import "material-theme-builder/tailwind.css";
 ```
 
-> [!NOTE]
->
-> Mostly there from before the plugin. One thing it still does that the plugin
-> cannot: imported AFTER a `@theme inline` of yours (shadcn's, say), it wins —
-> Tailwind gives a CSS `@theme` precedence over a plugin's theme.
-
 > [!IMPORTANT]
 >
 > Do not forget to manually add your custom colors, as in:
@@ -262,6 +256,7 @@ onto the m3 roles, for both modes at once:
 ```css
 /* globals.css */
 @import "tailwindcss";
+@import "material-theme-builder/shadcn.css";
 
 :root {
   /* ... */
@@ -269,20 +264,22 @@ onto the m3 roles, for both modes at once:
 .dark {
   /* ... */
 }
-
-@import "material-theme-builder/shadcn.css";
 ```
 
-> [!IMPORTANT]
+> [!NOTE]
 >
-> Make sure it comes AFTER `:root { ... } .dark { ... }` to take precedence.
+> Position does not matter: the block is written `:root:root, .dark.dark`, one
+> specificity step above shadcn's own — bundlers hoist `@import` to the top of
+> the sheet (Vite does), so source order could not be relied on. To override
+> one of these yourself, match that specificity, e.g.
+> `:root:root { --primary: … }`
 
 <details>
   <summary>what it remaps</summary>
 
 ```css
-:root,
-.dark {
+:root:root,
+.dark.dark {
   --background: var(--md-sys-color-surface);
   --foreground: var(--md-sys-color-on-surface);
   --card: var(--md-sys-color-surface-container-low);
@@ -323,8 +320,12 @@ In full in
 > With the Tailwind plugin too: on the names they share (`primary`,
 > `secondary`, `background`), shadcn's `@theme inline` wins whatever the order
 > — Tailwind gives a CSS `@theme` precedence over a plugin's. Those utilities
-> keep shadcn's semantics, already pointed at m3 by the import above. To flip
-> it, `@import "material-theme-builder/tailwind.css"` after shadcn's block.
+> keep shadcn's semantics, already pointed at m3 by the import above. Only
+> `secondary` differs in value — shadcn points it at the container role. To
+> take that one back, write the line yourself in `globals.css`:
+> `@theme inline { --color-secondary: var(--md-sys-color-secondary); }`. It has
+> to be written, not imported: bundlers hoist `@import` to the top of the sheet
+> (Vite does), which would put it back below shadcn's.
 
 > [!NOTE]
 >

--- a/README.md
+++ b/README.md
@@ -127,146 +127,83 @@ return (
 
 ## Tailwind
 
-Compatible through [theme variables](https://tailwindcss.com/docs/theme):
+A [Tailwind v4](https://tailwindcss.com) plugin ships with the package — one
+line, no theme block to maintain:
+
+```css
+@import "tailwindcss";
+@plugin "material-theme-builder/tailwind";
+```
+
+Every M3 role is now a Tailwind color:
+
+```html
+<p class="bg-surface-container-high text-on-surface border-outline-variant">
+  Hello, <span class="bg-primary-container text-on-primary-container">m3</span>
+</p>
+```
+
+Shades come along too — `bg-primary-500`, `text-neutral-variant-800`,
+`bg-error-50` — each one backed by the matching tonal palette
+(`--md-ref-palette-primary-50` and friends), and opacity modifiers work as
+usual: `bg-primary/50`.
+
+### Custom colors
+
+Name the custom colors ("Extended colors") you declared on `builder()` or
+`<Mtb>`, spelled the same way:
+
+```css
+@plugin "material-theme-builder/tailwind" {
+  custom-colors: myCustomColor1, myCustomColor2;
+}
+```
+
+Each one registers its four M3 roles and its shades:
+
+```html
+<span class="bg-myCustomColor1 text-on-myCustomColor1">…</span>
+<span class="bg-myCustomColor1-container text-on-myCustomColor1-container"
+  >…</span
+>
+<span class="bg-myCustomColor1-300">…</span>
+```
+
+> [!NOTE]
+>
+> The kebab-cased spelling works too — `bg-my-custom-color-1` — matching the
+> CSS varnames.
+
+### Options
+
+| option          | default |                                                                                                   |
+| --------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `prefix`        | `"md"`  | CSS custom-property prefix — must match the one given to `builder()` / `<Mtb>`                    |
+| `custom-colors` | –       | Custom color names, comma-separated                                                               |
+| `shades`        | `true`  | Register the `50`…`950` shades. Turn it off to leave Tailwind's own `neutral-*` palette untouched |
+
+> [!NOTE]
+>
+> Option names are read case- and dash-insensitively — `custom-colors` and
+> `customColors` are the same option. The kebab spelling is the one to prefer:
+> Prettier lowercases CSS declaration names.
+
+<details>
+  <summary>Without the plugin</summary>
+
+The same theme is also shipped as a plain stylesheet:
+
+```css
+@import "material-theme-builder/tailwind.css";
+```
+
+It is `@theme inline { --color-*: var(--md-sys-color-*) }` written out by hand
+(see
+[`src/tailwind.css`](https://github.com/abernier/material-theme-builder/blob/main/src/tailwind.css)),
+so custom colors are on you:
 
 ```css
 @theme inline {
-  --color-background: var(--md-sys-color-background);
-  --color-on-background: var(--md-sys-color-on-background);
-  --color-surface: var(--md-sys-color-surface);
-  --color-surface-dim: var(--md-sys-color-surface-dim);
-  --color-surface-bright: var(--md-sys-color-surface-bright);
-  --color-surface-container-lowest: var(
-    --md-sys-color-surface-container-lowest
-  );
-  --color-surface-container-low: var(--md-sys-color-surface-container-low);
-  --color-surface-container: var(--md-sys-color-surface-container);
-  --color-surface-container-high: var(--md-sys-color-surface-container-high);
-  --color-surface-container-highest: var(
-    --md-sys-color-surface-container-highest
-  );
-  --color-on-surface: var(--md-sys-color-on-surface);
-  --color-on-surface-variant: var(--md-sys-color-on-surface-variant);
-  --color-outline: var(--md-sys-color-outline);
-  --color-outline-variant: var(--md-sys-color-outline-variant);
-  --color-inverse-surface: var(--md-sys-color-inverse-surface);
-  --color-inverse-on-surface: var(--md-sys-color-inverse-on-surface);
-  --color-primary: var(--md-sys-color-primary);
-  --color-on-primary: var(--md-sys-color-on-primary);
-  --color-primary-container: var(--md-sys-color-primary-container);
-  --color-on-primary-container: var(--md-sys-color-on-primary-container);
-  --color-primary-fixed: var(--md-sys-color-primary-fixed);
-  --color-primary-fixed-dim: var(--md-sys-color-primary-fixed-dim);
-  --color-on-primary-fixed: var(--md-sys-color-on-primary-fixed);
-  --color-on-primary-fixed-variant: var(
-    --md-sys-color-on-primary-fixed-variant
-  );
-  --color-inverse-primary: var(--md-sys-color-inverse-primary);
-  --color-secondary: var(--md-sys-color-secondary);
-  --color-on-secondary: var(--md-sys-color-on-secondary);
-  --color-secondary-container: var(--md-sys-color-secondary-container);
-  --color-on-secondary-container: var(--md-sys-color-on-secondary-container);
-  --color-secondary-fixed: var(--md-sys-color-secondary-fixed);
-  --color-secondary-fixed-dim: var(--md-sys-color-secondary-fixed-dim);
-  --color-on-secondary-fixed: var(--md-sys-color-on-secondary-fixed);
-  --color-on-secondary-fixed-variant: var(
-    --md-sys-color-on-secondary-fixed-variant
-  );
-  --color-tertiary: var(--md-sys-color-tertiary);
-  --color-on-tertiary: var(--md-sys-color-on-tertiary);
-  --color-tertiary-container: var(--md-sys-color-tertiary-container);
-  --color-on-tertiary-container: var(--md-sys-color-on-tertiary-container);
-  --color-tertiary-fixed: var(--md-sys-color-tertiary-fixed);
-  --color-tertiary-fixed-dim: var(--md-sys-color-tertiary-fixed-dim);
-  --color-on-tertiary-fixed: var(--md-sys-color-on-tertiary-fixed);
-  --color-on-tertiary-fixed-variant: var(
-    --md-sys-color-on-tertiary-fixed-variant
-  );
-  --color-error: var(--md-sys-color-error);
-  --color-on-error: var(--md-sys-color-on-error);
-  --color-error-container: var(--md-sys-color-error-container);
-  --color-on-error-container: var(--md-sys-color-on-error-container);
-  --color-scrim: var(--md-sys-color-scrim);
-  --color-shadow: var(--md-sys-color-shadow);
-
-  /* Shades */
-
-  --color-primary-50: var(--md-ref-palette-primary-95);
-  --color-primary-100: var(--md-ref-palette-primary-90);
-  --color-primary-200: var(--md-ref-palette-primary-80);
-  --color-primary-300: var(--md-ref-palette-primary-70);
-  --color-primary-400: var(--md-ref-palette-primary-60);
-  --color-primary-500: var(--md-ref-palette-primary-50);
-  --color-primary-600: var(--md-ref-palette-primary-40);
-  --color-primary-700: var(--md-ref-palette-primary-30);
-  --color-primary-800: var(--md-ref-palette-primary-20);
-  --color-primary-900: var(--md-ref-palette-primary-10);
-  --color-primary-950: var(--md-ref-palette-primary-5);
-
-  --color-secondary-50: var(--md-ref-palette-secondary-95);
-  --color-secondary-100: var(--md-ref-palette-secondary-90);
-  --color-secondary-200: var(--md-ref-palette-secondary-80);
-  --color-secondary-300: var(--md-ref-palette-secondary-70);
-  --color-secondary-400: var(--md-ref-palette-secondary-60);
-  --color-secondary-500: var(--md-ref-palette-secondary-50);
-  --color-secondary-600: var(--md-ref-palette-secondary-40);
-  --color-secondary-700: var(--md-ref-palette-secondary-30);
-  --color-secondary-800: var(--md-ref-palette-secondary-20);
-  --color-secondary-900: var(--md-ref-palette-secondary-10);
-  --color-secondary-950: var(--md-ref-palette-secondary-5);
-
-  --color-tertiary-50: var(--md-ref-palette-tertiary-95);
-  --color-tertiary-100: var(--md-ref-palette-tertiary-90);
-  --color-tertiary-200: var(--md-ref-palette-tertiary-80);
-  --color-tertiary-300: var(--md-ref-palette-tertiary-70);
-  --color-tertiary-400: var(--md-ref-palette-tertiary-60);
-  --color-tertiary-500: var(--md-ref-palette-tertiary-50);
-  --color-tertiary-600: var(--md-ref-palette-tertiary-40);
-  --color-tertiary-700: var(--md-ref-palette-tertiary-30);
-  --color-tertiary-800: var(--md-ref-palette-tertiary-20);
-  --color-tertiary-900: var(--md-ref-palette-tertiary-10);
-  --color-tertiary-950: var(--md-ref-palette-tertiary-5);
-
-  --color-error-50: var(--md-ref-palette-error-95);
-  --color-error-100: var(--md-ref-palette-error-90);
-  --color-error-200: var(--md-ref-palette-error-80);
-  --color-error-300: var(--md-ref-palette-error-70);
-  --color-error-400: var(--md-ref-palette-error-60);
-  --color-error-500: var(--md-ref-palette-error-50);
-  --color-error-600: var(--md-ref-palette-error-40);
-  --color-error-700: var(--md-ref-palette-error-30);
-  --color-error-800: var(--md-ref-palette-error-20);
-  --color-error-900: var(--md-ref-palette-error-10);
-  --color-error-950: var(--md-ref-palette-error-5);
-
-  --color-neutral-50: var(--md-ref-palette-neutral-95);
-  --color-neutral-100: var(--md-ref-palette-neutral-90);
-  --color-neutral-200: var(--md-ref-palette-neutral-80);
-  --color-neutral-300: var(--md-ref-palette-neutral-70);
-  --color-neutral-400: var(--md-ref-palette-neutral-60);
-  --color-neutral-500: var(--md-ref-palette-neutral-50);
-  --color-neutral-600: var(--md-ref-palette-neutral-40);
-  --color-neutral-700: var(--md-ref-palette-neutral-30);
-  --color-neutral-800: var(--md-ref-palette-neutral-20);
-  --color-neutral-900: var(--md-ref-palette-neutral-10);
-  --color-neutral-950: var(--md-ref-palette-neutral-5);
-
-  --color-neutral-variant-50: var(--md-ref-palette-neutral-variant-95);
-  --color-neutral-variant-100: var(--md-ref-palette-neutral-variant-90);
-  --color-neutral-variant-200: var(--md-ref-palette-neutral-variant-80);
-  --color-neutral-variant-300: var(--md-ref-palette-neutral-variant-70);
-  --color-neutral-variant-400: var(--md-ref-palette-neutral-variant-60);
-  --color-neutral-variant-500: var(--md-ref-palette-neutral-variant-50);
-  --color-neutral-variant-600: var(--md-ref-palette-neutral-variant-40);
-  --color-neutral-variant-700: var(--md-ref-palette-neutral-variant-30);
-  --color-neutral-variant-800: var(--md-ref-palette-neutral-variant-20);
-  --color-neutral-variant-900: var(--md-ref-palette-neutral-variant-10);
-  --color-neutral-variant-950: var(--md-ref-palette-neutral-variant-5);
-
-  /*
-   * Custom colors
-   */
-
   --color-myCustomColor1: var(--md-sys-color-my-custom-color-1);
   --color-on-myCustomColor1: var(--md-sys-color-on-my-custom-color-1);
   --color-myCustomColor1-container: var(
@@ -287,87 +224,13 @@ Compatible through [theme variables](https://tailwindcss.com/docs/theme):
   --color-myCustomColor1-800: var(--md-ref-palette-my-custom-color-1-20);
   --color-myCustomColor1-900: var(--md-ref-palette-my-custom-color-1-10);
   --color-myCustomColor1-950: var(--md-ref-palette-my-custom-color-1-5);
-
-  --color-myCustomColor2: var(--md-sys-color-my-custom-color-2);
-  --color-on-myCustomColor2: var(--md-sys-color-on-my-custom-color-2);
-  --color-myCustomColor2-container: var(
-    --md-sys-color-my-custom-color-2-container
-  );
-  --color-on-myCustomColor2-container: var(
-    --md-sys-color-on-my-custom-color-2-container
-  );
-  /* Shades */
-  --color-myCustomColor2-50: var(--md-ref-palette-my-custom-color-2-95);
-  --color-myCustomColor2-100: var(--md-ref-palette-my-custom-color-2-90);
-  --color-myCustomColor2-200: var(--md-ref-palette-my-custom-color-2-80);
-  --color-myCustomColor2-300: var(--md-ref-palette-my-custom-color-2-70);
-  --color-myCustomColor2-400: var(--md-ref-palette-my-custom-color-2-60);
-  --color-myCustomColor2-500: var(--md-ref-palette-my-custom-color-2-50);
-  --color-myCustomColor2-600: var(--md-ref-palette-my-custom-color-2-40);
-  --color-myCustomColor2-700: var(--md-ref-palette-my-custom-color-2-30);
-  --color-myCustomColor2-800: var(--md-ref-palette-my-custom-color-2-20);
-  --color-myCustomColor2-900: var(--md-ref-palette-my-custom-color-2-10);
-  --color-myCustomColor2-950: var(--md-ref-palette-my-custom-color-2-5);
 }
 ```
 
-Or simply:
+`builder(…).toTailwind()` emits that same block, custom colors included, if you
+would rather generate it.
 
-```css
-@import "material-theme-builder/tailwind.css";
-```
-
-> [!IMPORTANT]
->
-> Do not forget to manually add your custom colors, as in:
->
-> ```css
-> /*
->  * Custom colors
->  */
->
-> --color-myCustomColor1: var(--md-sys-color-my-custom-color-1);
-> --color-on-myCustomColor1: var(--md-sys-color-on-my-custom-color-1);
-> --color-myCustomColor1-container: var(
->   --md-sys-color-my-custom-color-1-container
-> );
-> --color-on-myCustomColor1-container: var(
->   --md-sys-color-on-my-custom-color-1-container
-> );
-> /* Shades */
-> --color-myCustomColor1-50: var(--md-ref-palette-my-custom-color-1-95);
-> --color-myCustomColor1-100: var(--md-ref-palette-my-custom-color-1-90);
-> --color-myCustomColor1-200: var(--md-ref-palette-my-custom-color-1-80);
-> --color-myCustomColor1-300: var(--md-ref-palette-my-custom-color-1-70);
-> --color-myCustomColor1-400: var(--md-ref-palette-my-custom-color-1-60);
-> --color-myCustomColor1-500: var(--md-ref-palette-my-custom-color-1-50);
-> --color-myCustomColor1-600: var(--md-ref-palette-my-custom-color-1-40);
-> --color-myCustomColor1-700: var(--md-ref-palette-my-custom-color-1-30);
-> --color-myCustomColor1-800: var(--md-ref-palette-my-custom-color-1-20);
-> --color-myCustomColor1-900: var(--md-ref-palette-my-custom-color-1-10);
-> --color-myCustomColor1-950: var(--md-ref-palette-my-custom-color-1-5);
->
-> --color-myCustomColor2: var(--md-sys-color-my-custom-color-2);
-> --color-on-myCustomColor2: var(--md-sys-color-on-my-custom-color-2);
-> --color-myCustomColor2-container: var(
->   --md-sys-color-my-custom-color-2-container
-> );
-> --color-on-myCustomColor2-container: var(
->   --md-sys-color-on-my-custom-color-2-container
-> );
-> /* Shades */
-> --color-myCustomColor2-50: var(--md-ref-palette-my-custom-color-2-95);
-> --color-myCustomColor2-100: var(--md-ref-palette-my-custom-color-2-90);
-> --color-myCustomColor2-200: var(--md-ref-palette-my-custom-color-2-80);
-> --color-myCustomColor2-300: var(--md-ref-palette-my-custom-color-2-70);
-> --color-myCustomColor2-400: var(--md-ref-palette-my-custom-color-2-60);
-> --color-myCustomColor2-500: var(--md-ref-palette-my-custom-color-2-50);
-> --color-myCustomColor2-600: var(--md-ref-palette-my-custom-color-2-40);
-> --color-myCustomColor2-700: var(--md-ref-palette-my-custom-color-2-30);
-> --color-myCustomColor2-800: var(--md-ref-palette-my-custom-color-2-20);
-> --color-myCustomColor2-900: var(--md-ref-palette-my-custom-color-2-10);
-> --color-myCustomColor2-950: var(--md-ref-palette-my-custom-color-2-5);
-> ```
+</details>
 
 ## shadcn
 
@@ -376,10 +239,13 @@ Pre-requisites:
 - You should use
   [`tailwind.cssVariables`](https://ui.shadcn.com/docs/theming#css-variables)
 
-Simply override/remap
-[shadcn's CSS variables](https://ui.shadcn.com/docs/theming#list-of-variables):
+One import — no variable block to copy:
 
 ```css
+/* globals.css */
+@import "tailwindcss";
+@import "tw-animate-css";
+
 :root {
   /* ... */
 }
@@ -387,41 +253,19 @@ Simply override/remap
   /* ... */
 }
 
-:root,
-.dark {
-  --background: var(--md-sys-color-surface);
-  --foreground: var(--md-sys-color-on-surface);
-  --card: var(--md-sys-color-surface-container-low);
-  --card-foreground: var(--md-sys-color-on-surface);
-  --popover: var(--md-sys-color-surface-container-high);
-  --popover-foreground: var(--md-sys-color-on-surface);
-  --primary: var(--md-sys-color-primary);
-  --primary-foreground: var(--md-sys-color-on-primary);
-  --secondary: var(--md-sys-color-secondary-container);
-  --secondary-foreground: var(--md-sys-color-on-secondary-container);
-  --muted: var(--md-sys-color-surface-container-highest);
-  --muted-foreground: var(--md-sys-color-on-surface-variant);
-  --accent: var(--md-sys-color-secondary-container);
-  --accent-foreground: var(--md-sys-color-on-secondary-container);
-  --destructive: var(--md-sys-color-error);
-  --border: var(--md-sys-color-outline-variant);
-  --input: var(--md-sys-color-outline);
-  --ring: var(--md-sys-color-primary);
-  --chart-1: var(--md-sys-color-primary-fixed);
-  --chart-2: var(--md-sys-color-secondary-fixed);
-  --chart-3: var(--md-sys-color-tertiary-fixed);
-  --chart-4: var(--md-sys-color-primary-fixed-dim);
-  --chart-5: var(--md-sys-color-secondary-fixed-dim);
-  --sidebar: var(--md-sys-color-surface-container-low);
-  --sidebar-foreground: var(--md-sys-color-on-surface);
-  --sidebar-primary: var(--md-sys-color-primary);
-  --sidebar-primary-foreground: var(--md-sys-color-on-primary);
-  --sidebar-accent: var(--md-sys-color-secondary-container);
-  --sidebar-accent-foreground: var(--md-sys-color-on-secondary-container);
-  --sidebar-border: var(--md-sys-color-outline-variant);
-  --sidebar-ring: var(--md-sys-color-primary);
-}
+@import "material-theme-builder/shadcn.css";
 ```
+
+It remaps [shadcn's CSS
+variables](https://ui.shadcn.com/docs/theming#list-of-variables) onto the M3
+roles, for both modes at once — `--background` → `--md-sys-color-surface`,
+`--muted-foreground` → `--md-sys-color-on-surface-variant`, and so on (see
+[`src/shadcn.css`](https://github.com/abernier/material-theme-builder/blob/main/src/shadcn.css)).
+
+> [!IMPORTANT]
+>
+> Import it AFTER shadcn's own `:root { ... } .dark { ... }`, to take
+> precedence.
 
 <details>
   <summary>mapping details</summary>
@@ -431,10 +275,16 @@ Simply override/remap
     - https://gemini.google.com/share/51e072b6f1d2
 </details>
 
-> [!IMPORTANT]
+> [!NOTE]
 >
-> Make sure `:root, .dark { ... }` comes AFTER `.root { ... } .dark { ... }` to
-> take precedence.
+> Using the Tailwind plugin alongside shadcn? For the few color names they
+> share — `primary`, `secondary`, `background` — shadcn's `@theme inline` block
+> wins, whatever the order: Tailwind gives a CSS `@theme` precedence over a
+> plugin's theme. Those utilities keep shadcn's semantics, which the import
+> above has already pointed at M3.
+
+`builder(…).toShadcn()` is also there, if you would rather ship concrete oklch
+values (a registry theme, say) than variables that follow `<Mtb>` at runtime.
 
 # Dev
 

--- a/README.md
+++ b/README.md
@@ -127,31 +127,19 @@ return (
 
 ## Tailwind
 
-A [Tailwind v4](https://tailwindcss.com) plugin ships with the package — one
-line, no theme block to maintain:
+Compatible through a
+[Tailwind 4 plugin](https://tailwindcss.com/docs/functions-and-directives#plugin-directive):
 
 ```css
 @import "tailwindcss";
 @plugin "material-theme-builder/tailwind";
 ```
 
-Every M3 role is now a Tailwind color:
+→ `bg-surface-container-high`, `text-on-primary-container`,
+`border-outline-variant`… every m3 role, plus shades: `bg-primary-500`,
+`text-neutral-variant-800`. Opacity modifiers work: `bg-primary/50`.
 
-```html
-<p class="bg-surface-container-high text-on-surface border-outline-variant">
-  Hello, <span class="bg-primary-container text-on-primary-container">m3</span>
-</p>
-```
-
-Shades come along too — `bg-primary-500`, `text-neutral-variant-800`,
-`bg-error-50` — each one backed by the matching tonal palette
-(`--md-ref-palette-primary-50` and friends), and opacity modifiers work as
-usual: `bg-primary/50`.
-
-### Custom colors
-
-Name the custom colors ("Extended colors") you declared on `builder()` or
-`<Mtb>`, spelled the same way:
+Custom colors must be named — they only exist at runtime:
 
 ```css
 @plugin "material-theme-builder/tailwind" {
@@ -159,78 +147,106 @@ Name the custom colors ("Extended colors") you declared on `builder()` or
 }
 ```
 
-Each one registers its four M3 roles and its shades:
+→ `bg-myCustomColor1`, `text-on-myCustomColor1`,
+`bg-myCustomColor1-container`, `bg-myCustomColor1-300`
 
-```html
-<span class="bg-myCustomColor1 text-on-myCustomColor1">…</span>
-<span class="bg-myCustomColor1-container text-on-myCustomColor1-container"
-  >…</span
->
-<span class="bg-myCustomColor1-300">…</span>
-```
+Options:
 
-> [!NOTE]
->
-> The kebab-cased spelling works too — `bg-my-custom-color-1` — matching the
-> CSS varnames.
-
-### Options
-
-| option          | default |                                                                                                   |
-| --------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `prefix`        | `"md"`  | CSS custom-property prefix — must match the one given to `builder()` / `<Mtb>`                    |
-| `custom-colors` | –       | Custom color names, comma-separated                                                               |
-| `shades`        | `true`  | Register the `50`…`950` shades. Turn it off to leave Tailwind's own `neutral-*` palette untouched |
+| option          | default |                                    |
+| --------------- | ------- | ---------------------------------- |
+| `prefix`        | `"md"`  | same as `builder()` / `<Mtb>`      |
+| `custom-colors` | –       | comma-separated                    |
+| `shades`        | `true`  | `50`…`950`, off the tonal palettes |
 
 > [!NOTE]
 >
-> Option names are read case- and dash-insensitively — `custom-colors` and
-> `customColors` are the same option. The kebab spelling is the one to prefer:
-> Prettier lowercases CSS declaration names.
+> Custom colors also answer to their kebab spelling, e.g.
+> `bg-my-custom-color-1`
+
+> [!NOTE]
+>
+> Option names are read case- and dash-insensitively, e.g. `custom-colors` =
+> `customColors`. Prefer the kebab one: Prettier lowercases CSS declaration
+> names.
 
 <details>
-  <summary>Without the plugin</summary>
+  <summary>what it registers</summary>
 
-The same theme is also shipped as a plain stylesheet:
+Two rules, nothing else:
+
+- `--md-sys-color-<role>` → `--color-<role>`
+- shade → tone:
+
+  | shade | 50  | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 950 |
+  | ----- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+  | tone  | 95  | 90  | 80  | 70  | 60  | 50  | 40  | 30  | 20  | 10  | 5   |
+
+  on `primary`, `secondary`, `tertiary`, `error`, `neutral`,
+  `neutral-variant`, and every custom color.
+
+```css
+@theme inline {
+  --color-background: var(--md-sys-color-background);
+  --color-surface: var(--md-sys-color-surface);
+  --color-surface-container: var(--md-sys-color-surface-container);
+  --color-on-surface: var(--md-sys-color-on-surface);
+  --color-outline-variant: var(--md-sys-color-outline-variant);
+  --color-primary: var(--md-sys-color-primary);
+  --color-on-primary: var(--md-sys-color-on-primary);
+  --color-primary-container: var(--md-sys-color-primary-container);
+  /* …one per role: secondary, tertiary, error, the -fixed and inverse-*
+     variants, scrim, shadow… */
+
+  /* Shades */
+
+  --color-primary-50: var(--md-ref-palette-primary-95);
+  --color-primary-100: var(--md-ref-palette-primary-90);
+  /* …200 → 800… */
+  --color-primary-950: var(--md-ref-palette-primary-5);
+
+  /* …idem secondary, tertiary, error, neutral, neutral-variant… */
+}
+```
+
+In full in
+[`src/tailwind.css`](https://github.com/abernier/material-theme-builder/blob/main/src/tailwind.css).
+
+</details>
+
+Or simply, the same theme as a stylesheet:
 
 ```css
 @import "material-theme-builder/tailwind.css";
 ```
 
-It is `@theme inline { --color-*: var(--md-sys-color-*) }` written out by hand
-(see
-[`src/tailwind.css`](https://github.com/abernier/material-theme-builder/blob/main/src/tailwind.css)),
-so custom colors are on you:
+> [!NOTE]
+>
+> Mostly there from before the plugin. One thing it still does that the plugin
+> cannot: imported AFTER a `@theme inline` of yours (shadcn's, say), it wins —
+> Tailwind gives a CSS `@theme` precedence over a plugin's theme.
 
-```css
-@theme inline {
-  --color-myCustomColor1: var(--md-sys-color-my-custom-color-1);
-  --color-on-myCustomColor1: var(--md-sys-color-on-my-custom-color-1);
-  --color-myCustomColor1-container: var(
-    --md-sys-color-my-custom-color-1-container
-  );
-  --color-on-myCustomColor1-container: var(
-    --md-sys-color-on-my-custom-color-1-container
-  );
-  /* Shades */
-  --color-myCustomColor1-50: var(--md-ref-palette-my-custom-color-1-95);
-  --color-myCustomColor1-100: var(--md-ref-palette-my-custom-color-1-90);
-  --color-myCustomColor1-200: var(--md-ref-palette-my-custom-color-1-80);
-  --color-myCustomColor1-300: var(--md-ref-palette-my-custom-color-1-70);
-  --color-myCustomColor1-400: var(--md-ref-palette-my-custom-color-1-60);
-  --color-myCustomColor1-500: var(--md-ref-palette-my-custom-color-1-50);
-  --color-myCustomColor1-600: var(--md-ref-palette-my-custom-color-1-40);
-  --color-myCustomColor1-700: var(--md-ref-palette-my-custom-color-1-30);
-  --color-myCustomColor1-800: var(--md-ref-palette-my-custom-color-1-20);
-  --color-myCustomColor1-900: var(--md-ref-palette-my-custom-color-1-10);
-  --color-myCustomColor1-950: var(--md-ref-palette-my-custom-color-1-5);
-}
-```
-
-`builder(…).toTailwind()` emits that same block, custom colors included, if you
-would rather generate it.
-
-</details>
+> [!IMPORTANT]
+>
+> Do not forget to manually add your custom colors, as in:
+>
+> ```css
+> @theme inline {
+>   --color-myCustomColor1: var(--md-sys-color-my-custom-color-1);
+>   --color-on-myCustomColor1: var(--md-sys-color-on-my-custom-color-1);
+>   --color-myCustomColor1-container: var(
+>     --md-sys-color-my-custom-color-1-container
+>   );
+>   --color-on-myCustomColor1-container: var(
+>     --md-sys-color-on-my-custom-color-1-container
+>   );
+>   /* Shades */
+>   --color-myCustomColor1-50: var(--md-ref-palette-my-custom-color-1-95);
+>   /* …100 → 900… */
+>   --color-myCustomColor1-950: var(--md-ref-palette-my-custom-color-1-5);
+> }
+> ```
+>
+> `builder(…).toTailwind()` emits the whole block, custom colors included.
 
 ## shadcn
 
@@ -239,12 +255,13 @@ Pre-requisites:
 - You should use
   [`tailwind.cssVariables`](https://ui.shadcn.com/docs/theming#css-variables)
 
-One import — no variable block to copy:
+One import remaps
+[shadcn's CSS variables](https://ui.shadcn.com/docs/theming#list-of-variables)
+onto the m3 roles, for both modes at once:
 
 ```css
 /* globals.css */
 @import "tailwindcss";
-@import "tw-animate-css";
 
 :root {
   /* ... */
@@ -256,16 +273,42 @@ One import — no variable block to copy:
 @import "material-theme-builder/shadcn.css";
 ```
 
-It remaps [shadcn's CSS
-variables](https://ui.shadcn.com/docs/theming#list-of-variables) onto the M3
-roles, for both modes at once — `--background` → `--md-sys-color-surface`,
-`--muted-foreground` → `--md-sys-color-on-surface-variant`, and so on (see
-[`src/shadcn.css`](https://github.com/abernier/material-theme-builder/blob/main/src/shadcn.css)).
-
 > [!IMPORTANT]
 >
-> Import it AFTER shadcn's own `:root { ... } .dark { ... }`, to take
-> precedence.
+> Make sure it comes AFTER `:root { ... } .dark { ... }` to take precedence.
+
+<details>
+  <summary>what it remaps</summary>
+
+```css
+:root,
+.dark {
+  --background: var(--md-sys-color-surface);
+  --foreground: var(--md-sys-color-on-surface);
+  --card: var(--md-sys-color-surface-container-low);
+  --popover: var(--md-sys-color-surface-container-high);
+  --muted: var(--md-sys-color-surface-container-highest);
+  --muted-foreground: var(--md-sys-color-on-surface-variant);
+  --primary: var(--md-sys-color-primary);
+  --secondary: var(--md-sys-color-secondary-container);
+  --accent: var(--md-sys-color-secondary-container);
+  --destructive: var(--md-sys-color-error);
+  --border: var(--md-sys-color-outline-variant);
+  --input: var(--md-sys-color-outline);
+  --ring: var(--md-sys-color-primary);
+  /* …the -foreground of each, --chart-1…5 off the -fixed roles,
+     --sidebar-* mirroring the above… */
+}
+```
+
+Surfaces come from the surface containers, `--secondary` / `--accent` from
+`secondary-container` (shadcn uses them as tinted fills — the container role,
+not m3's `secondary`), borders from `outline-variant`, ring from `primary`.
+
+In full in
+[`src/shadcn.css`](https://github.com/abernier/material-theme-builder/blob/main/src/shadcn.css).
+
+</details>
 
 <details>
   <summary>mapping details</summary>
@@ -277,14 +320,16 @@ roles, for both modes at once — `--background` → `--md-sys-color-surface`,
 
 > [!NOTE]
 >
-> Using the Tailwind plugin alongside shadcn? For the few color names they
-> share — `primary`, `secondary`, `background` — shadcn's `@theme inline` block
-> wins, whatever the order: Tailwind gives a CSS `@theme` precedence over a
-> plugin's theme. Those utilities keep shadcn's semantics, which the import
-> above has already pointed at M3.
+> With the Tailwind plugin too: on the names they share (`primary`,
+> `secondary`, `background`), shadcn's `@theme inline` wins whatever the order
+> — Tailwind gives a CSS `@theme` precedence over a plugin's. Those utilities
+> keep shadcn's semantics, already pointed at m3 by the import above. To flip
+> it, `@import "material-theme-builder/tailwind.css"` after shadcn's block.
 
-`builder(…).toShadcn()` is also there, if you would rather ship concrete oklch
-values (a registry theme, say) than variables that follow `<Mtb>` at runtime.
+> [!NOTE]
+>
+> `builder(…).toShadcn()` emits concrete oklch values instead — for a registry
+> theme, say.
 
 # Dev
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
       "types": "./dist/react.d.ts",
       "import": "./dist/react.js"
     },
-    "./tailwind.css": "./dist/tailwind.css"
+    "./tailwind": {
+      "types": "./dist/tailwind.d.ts",
+      "import": "./dist/tailwind.js"
+    },
+    "./tailwind.css": "./dist/tailwind.css",
+    "./shadcn.css": "./dist/shadcn.css"
   },
   "homepage": "https://github.com/abernier/material-theme-builder",
   "bugs": {
@@ -30,7 +35,8 @@
   "license": "MIT",
   "files": [
     "dist",
-    "src/tailwind.css"
+    "src/tailwind.css",
+    "src/shadcn.css"
   ],
   "bin": {
     "material-theme-builder": "./dist/cli.js"
@@ -116,7 +122,13 @@
   },
   "peerDependencies": {
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "tailwindcss": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@material/material-color-utilities": "^0.3.0",

--- a/src/lib/builder.tailwind.ts
+++ b/src/lib/builder.tailwind.ts
@@ -3,8 +3,14 @@ import { kebabCase } from "lodash-es";
 import type { BuilderContext } from "./builder";
 import { SHADCN_MAPPING } from "./builder.shadcn";
 
-// Tailwind shade → M3 tone mapping
-const SHADE_TO_TONE = [
+/**
+ * Tailwind shade → M3 tone mapping.
+ *
+ * Shared with the Tailwind plugin (`material-theme-builder/tailwind`), so the
+ * `@theme inline` block `toTailwind()` writes and the theme the plugin
+ * registers cannot drift apart.
+ */
+export const SHADE_TO_TONE = [
   [50, 95],
   [100, 90],
   [200, 80],
@@ -18,8 +24,8 @@ const SHADE_TO_TONE = [
   [950, 5],
 ] as const;
 
-// Core palette names that receive shade mappings
-const CORE_PALETTES = [
+/** Core palette names that receive shade mappings. */
+export const CORE_PALETTES = [
   "primary",
   "secondary",
   "tertiary",

--- a/src/lib/builder.tailwind.ts
+++ b/src/lib/builder.tailwind.ts
@@ -95,6 +95,10 @@ export function buildTailwind(ctx: BuilderContext, options?: TailwindOptions) {
       ([shadcnVar, m3Token]) =>
         `${shadcnVar}: var(--${prefix}-sys-color-${m3Token});`,
     );
+    // Plain `:root` / `.dark` here: this block gets pasted, so where it lands
+    // -- and therefore what it outranks -- is the reader's call. The shipped
+    // `shadcn.css` doubles the selectors instead, because an `@import` is at
+    // the mercy of whatever the bundler does with it.
     output += `\n:root,\n.dark {\n  ${shadcnLines.join("\n  ")}\n}\n`;
   }
 

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -23,6 +23,7 @@ import { buildFlutter } from "./builder.flutter";
 import { buildJson } from "./builder.json";
 import { buildShadcn } from "./builder.shadcn";
 import { buildTailwind, type TailwindOptions } from "./builder.tailwind";
+import { DEFAULT_PREFIX, tokenNames } from "./tokens";
 
 // ─── Re-exports (types defined alongside their exporter) ─────────────────
 
@@ -133,8 +134,6 @@ export const DEFAULT_CONTRAST = 0;
 export const DEFAULT_CUSTOM_COLORS: HexCustomColor[] = [];
 /** Default blend mode — harmonize custom colors with source. */
 export const DEFAULT_BLEND = true;
-/** Default CSS custom-property prefix. */
-export const DEFAULT_PREFIX = "md";
 
 /** The 28 standard tone values used in Material You tonal palettes. */
 export const STANDARD_TONES = [
@@ -167,114 +166,17 @@ export const schemeToVariant = {
 } satisfies Record<SchemeName, number>;
 
 // ─── Token descriptions ──────────────────────────────────────────────────
+//
+// Defined in `./tokens`, which the Tailwind plugin also reads; re-exported
+// here so the public surface stays where it always was.
 
-/**
- * Material Design 3 token names and their descriptions.
- *
- * Centralizes both the canonical list of scheme tokens and their M3 color role semantics.
- *
- * @see https://m3.material.io/styles/color/the-color-system/color-roles
- */
-export const tokenDescriptions = {
-  background: "Default background color for screens and large surfaces.",
-  error: "Color for error states, used on elements like error text and icons.",
-  errorContainer: "Fill color for error container elements like error banners.",
-  inverseOnSurface: "Color for text and icons on inverse surface backgrounds.",
-  inversePrimary:
-    "Primary color used on inverse surface, e.g. buttons on snackbars.",
-  inverseSurface:
-    "Background for elements that require reverse contrast, such as snackbars.",
-  onBackground: "Color for text and icons displayed on the background.",
-  onError: "Color for text and icons on error-colored elements.",
-  onErrorContainer: "Color for text and icons on error container elements.",
-  onPrimary:
-    "Color for text and icons on primary-colored elements like filled buttons.",
-  onPrimaryContainer:
-    "Color for text and icons on primary container elements like tonal buttons.",
-  onPrimaryFixed:
-    "Color for text and icons on primary fixed elements, constant across themes.",
-  onPrimaryFixedVariant:
-    "Lower-emphasis color for text and icons on primary fixed elements.",
-  onSecondary: "Color for text and icons on secondary-colored elements.",
-  onSecondaryContainer:
-    "Color for text and icons on secondary container elements.",
-  onSecondaryFixed:
-    "Color for text and icons on secondary fixed elements, constant across themes.",
-  onSecondaryFixedVariant:
-    "Lower-emphasis color for text and icons on secondary fixed elements.",
-  onSurface: "High-emphasis color for text and icons on surface backgrounds.",
-  onSurfaceVariant:
-    "Medium-emphasis color for text and icons on surface variant backgrounds.",
-  onTertiary: "Color for text and icons on tertiary-colored elements.",
-  onTertiaryContainer:
-    "Color for text and icons on tertiary container elements.",
-  onTertiaryFixed:
-    "Color for text and icons on tertiary fixed elements, constant across themes.",
-  onTertiaryFixedVariant:
-    "Lower-emphasis color for text and icons on tertiary fixed elements.",
-  outline: "Subtle color for borders and dividers to create visual separation.",
-  outlineVariant: "Lower-emphasis border color used for decorative dividers.",
-  primary:
-    "Main brand color, used for key components like filled buttons and active states.",
-  primaryContainer:
-    "Fill color for large primary elements like cards and tonal buttons.",
-  primaryFixed:
-    "Fixed primary color that stays the same in light and dark themes.",
-  primaryFixedDim:
-    "Dimmed variant of the fixed primary color for lower emphasis.",
-  scrim: "Color overlay for modals and dialogs to obscure background content.",
-  secondary:
-    "Accent color for less prominent elements like filter chips and selections.",
-  secondaryContainer:
-    "Fill color for secondary container elements like tonal buttons and input fields.",
-  secondaryFixed:
-    "Fixed secondary color that stays the same in light and dark themes.",
-  secondaryFixedDim:
-    "Dimmed variant of the fixed secondary color for lower emphasis.",
-  shadow: "Color for elevation shadows applied to surfaces and components.",
-  surface: "Default surface color for cards, sheets, and dialogs.",
-  surfaceBright:
-    "Brightest surface variant, used for elevated surfaces in dark themes.",
-  surfaceContainer:
-    "Middle-emphasis container color for grouping related content.",
-  surfaceContainerHigh:
-    "Higher-emphasis container color for elements like cards.",
-  surfaceContainerHighest:
-    "Highest-emphasis container color for text fields and other input areas.",
-  surfaceContainerLow:
-    "Lower-emphasis container color for subtle surface groupings.",
-  surfaceContainerLowest:
-    "Lowest-emphasis container, typically the lightest surface in light theme.",
-  surfaceDim:
-    "Dimmest surface variant, used for recessed areas or dark theme backgrounds.",
-  surfaceTint:
-    "Tint color applied to surfaces for subtle primary color elevation overlay.",
-  surfaceVariant:
-    "Alternative surface color for differentiated areas like sidebar backgrounds.",
-  tertiary:
-    "Third accent color for complementary elements that balance primary and secondary.",
-  tertiaryContainer:
-    "Fill color for tertiary container elements like complementary cards.",
-  tertiaryFixed:
-    "Fixed tertiary color that stays the same in light and dark themes.",
-  tertiaryFixedDim:
-    "Dimmed variant of the fixed tertiary color for lower emphasis.",
-} as const;
-
-/**
- * Type-guard that checks whether a string is a known M3 color token name.
- */
-export function isTokenName(
-  key: string,
-): key is keyof typeof tokenDescriptions {
-  return key in tokenDescriptions;
-}
-
-/** All known M3 color token names. */
-export const tokenNames = Object.keys(tokenDescriptions).filter(isTokenName);
-
-/** Union of all known M3 color token names. */
-export type TokenName = keyof typeof tokenDescriptions;
+export {
+  DEFAULT_PREFIX,
+  isTokenName,
+  tokenDescriptions,
+  tokenNames,
+  type TokenName,
+} from "./tokens";
 
 // ─── Internal types ──────────────────────────────────────────────────────
 

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,0 +1,119 @@
+// M3 color-role names, standing on their own — no color engine, no builder
+// context. The Tailwind plugin (`material-theme-builder/tailwind`) runs inside
+// the CSS build and needs the names alone, so it imports them from here rather
+// than dragging `builder.ts` — and Material Color Utilities with it — along.
+
+/**
+ * Default CSS custom-property prefix — `--md-sys-color-*`, `--md-ref-palette-*`.
+ *
+ * Part of how the tokens are spelled, so it lives with them.
+ */
+export const DEFAULT_PREFIX = "md";
+
+/**
+ * Material Design 3 token names and their descriptions.
+ *
+ * Centralizes both the canonical list of scheme tokens and their M3 color role semantics.
+ *
+ * @see https://m3.material.io/styles/color/the-color-system/color-roles
+ */
+export const tokenDescriptions = {
+  background: "Default background color for screens and large surfaces.",
+  error: "Color for error states, used on elements like error text and icons.",
+  errorContainer: "Fill color for error container elements like error banners.",
+  inverseOnSurface: "Color for text and icons on inverse surface backgrounds.",
+  inversePrimary:
+    "Primary color used on inverse surface, e.g. buttons on snackbars.",
+  inverseSurface:
+    "Background for elements that require reverse contrast, such as snackbars.",
+  onBackground: "Color for text and icons displayed on the background.",
+  onError: "Color for text and icons on error-colored elements.",
+  onErrorContainer: "Color for text and icons on error container elements.",
+  onPrimary:
+    "Color for text and icons on primary-colored elements like filled buttons.",
+  onPrimaryContainer:
+    "Color for text and icons on primary container elements like tonal buttons.",
+  onPrimaryFixed:
+    "Color for text and icons on primary fixed elements, constant across themes.",
+  onPrimaryFixedVariant:
+    "Lower-emphasis color for text and icons on primary fixed elements.",
+  onSecondary: "Color for text and icons on secondary-colored elements.",
+  onSecondaryContainer:
+    "Color for text and icons on secondary container elements.",
+  onSecondaryFixed:
+    "Color for text and icons on secondary fixed elements, constant across themes.",
+  onSecondaryFixedVariant:
+    "Lower-emphasis color for text and icons on secondary fixed elements.",
+  onSurface: "High-emphasis color for text and icons on surface backgrounds.",
+  onSurfaceVariant:
+    "Medium-emphasis color for text and icons on surface variant backgrounds.",
+  onTertiary: "Color for text and icons on tertiary-colored elements.",
+  onTertiaryContainer:
+    "Color for text and icons on tertiary container elements.",
+  onTertiaryFixed:
+    "Color for text and icons on tertiary fixed elements, constant across themes.",
+  onTertiaryFixedVariant:
+    "Lower-emphasis color for text and icons on tertiary fixed elements.",
+  outline: "Subtle color for borders and dividers to create visual separation.",
+  outlineVariant: "Lower-emphasis border color used for decorative dividers.",
+  primary:
+    "Main brand color, used for key components like filled buttons and active states.",
+  primaryContainer:
+    "Fill color for large primary elements like cards and tonal buttons.",
+  primaryFixed:
+    "Fixed primary color that stays the same in light and dark themes.",
+  primaryFixedDim:
+    "Dimmed variant of the fixed primary color for lower emphasis.",
+  scrim: "Color overlay for modals and dialogs to obscure background content.",
+  secondary:
+    "Accent color for less prominent elements like filter chips and selections.",
+  secondaryContainer:
+    "Fill color for secondary container elements like tonal buttons and input fields.",
+  secondaryFixed:
+    "Fixed secondary color that stays the same in light and dark themes.",
+  secondaryFixedDim:
+    "Dimmed variant of the fixed secondary color for lower emphasis.",
+  shadow: "Color for elevation shadows applied to surfaces and components.",
+  surface: "Default surface color for cards, sheets, and dialogs.",
+  surfaceBright:
+    "Brightest surface variant, used for elevated surfaces in dark themes.",
+  surfaceContainer:
+    "Middle-emphasis container color for grouping related content.",
+  surfaceContainerHigh:
+    "Higher-emphasis container color for elements like cards.",
+  surfaceContainerHighest:
+    "Highest-emphasis container color for text fields and other input areas.",
+  surfaceContainerLow:
+    "Lower-emphasis container color for subtle surface groupings.",
+  surfaceContainerLowest:
+    "Lowest-emphasis container, typically the lightest surface in light theme.",
+  surfaceDim:
+    "Dimmest surface variant, used for recessed areas or dark theme backgrounds.",
+  surfaceTint:
+    "Tint color applied to surfaces for subtle primary color elevation overlay.",
+  surfaceVariant:
+    "Alternative surface color for differentiated areas like sidebar backgrounds.",
+  tertiary:
+    "Third accent color for complementary elements that balance primary and secondary.",
+  tertiaryContainer:
+    "Fill color for tertiary container elements like complementary cards.",
+  tertiaryFixed:
+    "Fixed tertiary color that stays the same in light and dark themes.",
+  tertiaryFixedDim:
+    "Dimmed variant of the fixed tertiary color for lower emphasis.",
+} as const;
+
+/**
+ * Type-guard that checks whether a string is a known M3 color token name.
+ */
+export function isTokenName(
+  key: string,
+): key is keyof typeof tokenDescriptions {
+  return key in tokenDescriptions;
+}
+
+/** All known M3 color token names. */
+export const tokenNames = Object.keys(tokenDescriptions).filter(isTokenName);
+
+/** Union of all known M3 color token names. */
+export type TokenName = keyof typeof tokenDescriptions;

--- a/src/shadcn.css
+++ b/src/shadcn.css
@@ -1,5 +1,14 @@
-:root,
-.dark {
+/*
+ * `:root:root` / `.dark.dark` rather than `:root` / `.dark`: same elements,
+ * one specificity step up, so this block beats shadcn's own wherever it lands
+ * -- a bundler may hoist this @import to the top of the sheet (Vite does), and
+ * an unlayered `:root` cannot be outranked by a layer.
+ *
+ * To override one of these yourself, match that specificity:
+ * `:root:root { --primary: … }`.
+ */
+:root:root,
+.dark.dark {
   --background: var(--md-sys-color-surface);
   --foreground: var(--md-sys-color-on-surface);
   --card: var(--md-sys-color-surface-container-low);

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -13,6 +13,8 @@
   --color-surface-container-highest: var(
     --md-sys-color-surface-container-highest
   );
+  --color-surface-tint: var(--md-sys-color-surface-tint);
+  --color-surface-variant: var(--md-sys-color-surface-variant);
   --color-on-surface: var(--md-sys-color-on-surface);
   --color-on-surface-variant: var(--md-sys-color-on-surface-variant);
   --color-outline: var(--md-sys-color-outline);

--- a/src/tailwind.test.ts
+++ b/src/tailwind.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { kebabCase } from "lodash-es";
+import { builder } from "./lib/builder";
+import { SHADCN_MAPPING } from "./lib/builder.shadcn";
+import { tokenNames } from "./lib/tokens";
+import mtbPlugin, { mtbColors, type MtbPluginOptions } from "./tailwind";
+
+// Flatten the Tailwind color theme the way Tailwind itself does: a scale
+// becomes `<name>-<shade>`, its `DEFAULT` the bare `<name>`. The result is the
+// set of `--color-*` names the plugin ends up defining.
+function colorVarNames(options?: MtbPluginOptions) {
+  const names: string[] = [];
+  for (const [name, value] of Object.entries(mtbColors(options))) {
+    if (typeof value === "string") {
+      names.push(name);
+      continue;
+    }
+    for (const shade of Object.keys(value)) {
+      names.push(shade === "DEFAULT" ? name : `${name}-${shade}`);
+    }
+  }
+  return names;
+}
+
+describe("tailwind plugin › mtbColors()", () => {
+  it("should register every M3 scheme token", () => {
+    const colors = mtbColors();
+    for (const token of tokenNames) {
+      const value = colors[kebabCase(token)];
+      const resolved = typeof value === "string" ? value : value?.DEFAULT;
+      expect(resolved).toBe(`var(--md-sys-color-${kebabCase(token)})`);
+    }
+  });
+
+  it("should register the same colors as toTailwind()", () => {
+    // The hand-written `@theme inline` block and the plugin are two spellings
+    // of one theme -- this is what keeps them from drifting apart.
+    const emitted = [
+      ...builder("#6750A4")
+        .toTailwind()
+        .matchAll(/--color-([\w-]+):/g),
+    ].map(([, name]) => name);
+
+    expect(colorVarNames().sort()).toEqual(emitted.sort());
+  });
+
+  it("should map shades onto tonal palette tones", () => {
+    const primary = mtbColors().primary;
+    expect(primary).toMatchObject({
+      DEFAULT: "var(--md-sys-color-primary)",
+      50: "var(--md-ref-palette-primary-95)",
+      500: "var(--md-ref-palette-primary-50)",
+      950: "var(--md-ref-palette-primary-5)",
+    });
+  });
+
+  it("should leave Tailwind's own palettes alone when shades are off", () => {
+    const colors = mtbColors({ shades: false });
+    expect(colors.neutral).toBeUndefined();
+    expect(colors.primary).toBe("var(--md-sys-color-primary)");
+  });
+
+  it("should read option names however they are spelled", () => {
+    // Prettier lowercases CSS declaration names, so a formatted stylesheet
+    // hands us `customcolors` -- it still has to work.
+    const expected = mtbColors({ customColors: "brand" });
+
+    expect(mtbColors({ "custom-colors": "brand" } as MtbPluginOptions)).toEqual(
+      expected,
+    );
+    expect(mtbColors({ customcolors: "brand" } as MtbPluginOptions)).toEqual(
+      expected,
+    );
+  });
+
+  it("should refuse an option it does not know", () => {
+    expect(() =>
+      mtbColors({ customColor: "brand" } as MtbPluginOptions),
+    ).toThrow(/Unknown option 'customColor'/);
+  });
+
+  it("should respect the prefix option", () => {
+    const colors = mtbColors({ prefix: "my" });
+    expect(colors["on-primary"]).toBe("var(--my-sys-color-on-primary)");
+    expect(colors.primary).toMatchObject({
+      500: "var(--my-ref-palette-primary-50)",
+    });
+  });
+
+  describe("custom colors", () => {
+    it("should register the four M3 roles, kebab-cased", () => {
+      const colors = mtbColors({ customColors: "myCustomColor1" });
+      expect(colors["my-custom-color-1"]).toMatchObject({
+        DEFAULT: "var(--md-sys-color-my-custom-color-1)",
+        300: "var(--md-ref-palette-my-custom-color-1-70)",
+      });
+      expect(colors["on-my-custom-color-1"]).toBe(
+        "var(--md-sys-color-on-my-custom-color-1)",
+      );
+      expect(colors["my-custom-color-1-container"]).toBe(
+        "var(--md-sys-color-my-custom-color-1-container)",
+      );
+      expect(colors["on-my-custom-color-1-container"]).toBe(
+        "var(--md-sys-color-on-my-custom-color-1-container)",
+      );
+    });
+
+    it("should also accept the name as written", () => {
+      const colors = mtbColors({ customColors: "myCustomColor1" });
+      expect(colors.myCustomColor1).toMatchObject({
+        DEFAULT: "var(--md-sys-color-my-custom-color-1)",
+      });
+      expect(colors["on-myCustomColor1"]).toBe(
+        "var(--md-sys-color-on-my-custom-color-1)",
+      );
+    });
+
+    it("should not duplicate a name already kebab-cased", () => {
+      const colors = mtbColors({ customColors: "brand" });
+      expect(Object.keys(colors).filter((k) => k.includes("brand"))).toEqual([
+        "brand",
+        "on-brand",
+        "brand-container",
+        "on-brand-container",
+      ]);
+    });
+
+    it("should accept a list, and tolerate CSS-authored scalars", () => {
+      // `@plugin { customColors: a, b }` yields an array; a lone value yields
+      // a scalar, numeric-looking if it can be.
+      expect(colorVarNames({ customColors: ["brand", "success"] })).toEqual(
+        expect.arrayContaining(["brand", "on-success-container"]),
+      );
+      expect(mtbColors({ customColors: 1 })["on-1"]).toBe(
+        "var(--md-sys-color-on-1)",
+      );
+    });
+  });
+});
+
+describe("tailwind plugin › default export", () => {
+  it("should be an options-taking Tailwind plugin", () => {
+    expect(mtbPlugin.__isOptionsFunction).toBe(true);
+  });
+
+  it("should expose the colors through its config", () => {
+    const { handler, config } = mtbPlugin({ customColors: "brand" });
+
+    expect(handler).toBeTypeOf("function");
+    expect(config).toEqual({
+      theme: { extend: { colors: mtbColors({ customColors: "brand" }) } },
+    });
+  });
+
+  it("should work without options", () => {
+    expect(mtbPlugin().config).toEqual({
+      theme: { extend: { colors: mtbColors() } },
+    });
+  });
+});
+
+// The shipped stylesheets predate the plugin and stay for backwards
+// compatibility -- so they have to keep saying the same thing it does.
+describe("shipped stylesheets", () => {
+  it("tailwind.css should define every color the plugin registers", () => {
+    const css = readFileSync("src/tailwind.css", "utf8");
+    const declared = new Set(
+      [...css.matchAll(/--color-([\w-]+):/g)].map(([, name]) => name),
+    );
+
+    expect(colorVarNames().filter((name) => !declared.has(name))).toEqual([]);
+  });
+
+  it("shadcn.css should remap every shadcn variable", () => {
+    const css = readFileSync("src/shadcn.css", "utf8");
+
+    for (const [cssVar, token] of SHADCN_MAPPING) {
+      expect(css).toContain(`${cssVar}: var(--md-sys-color-${token});`);
+    }
+  });
+});

--- a/src/tailwind.ts
+++ b/src/tailwind.ts
@@ -1,0 +1,164 @@
+import { kebabCase } from "lodash-es";
+import plugin from "tailwindcss/plugin";
+
+import { CORE_PALETTES, SHADE_TO_TONE } from "./lib/builder.tailwind";
+import { DEFAULT_PREFIX, tokenNames } from "./lib/tokens";
+
+/**
+ * Options for the Tailwind v4 plugin, spelled in CSS as an `@plugin` body:
+ *
+ * ```css
+ * @plugin "material-theme-builder/tailwind" {
+ *   custom-colors: myCustomColor1, myCustomColor2;
+ * }
+ * ```
+ *
+ * Option names are read case- and dash-insensitively, so `custom-colors` and
+ * `customColors` are one and the same — Prettier lowercases CSS declaration
+ * names, and a stylesheet that goes through it must not stop working.
+ */
+export type MtbPluginOptions = {
+  /**
+   * CSS custom-property prefix — must match the `prefix` given to `builder()`
+   * or `<Mtb>`.
+   *
+   * @default "md"
+   */
+  prefix?: string;
+  /**
+   * Names of the custom colors ("Extended colors") declared on `builder()` or
+   * `<Mtb>`, spelled exactly as they are there.
+   *
+   * Each one registers its four M3 roles (`brand`, `on-brand`,
+   * `brand-container`, `on-brand-container`) plus its shades.
+   */
+  customColors?: string | number | (string | number)[];
+  /**
+   * Register the `50`…`950` shades backed by the tonal palettes.
+   *
+   * Turning this off leaves Tailwind's own `neutral-*` palette untouched.
+   *
+   * @default true
+   */
+  shades?: boolean;
+};
+
+/** A Tailwind color entry: a single value, or a scale keyed by shade. */
+type ColorValue = string | Record<string, string>;
+
+// `@plugin` bodies are untyped CSS: a lone value arrives as a scalar, a
+// comma-separated list as an array, and every entry may be a number
+// (`custom-colors: color1` is a string, but nothing stops `color1` from
+// looking numeric).
+function toNameList(value: MtbPluginOptions["customColors"]) {
+  if (value === undefined) return [];
+  const values = Array.isArray(value) ? value : [value];
+  return values.map((name) => String(name).trim()).filter(Boolean);
+}
+
+// One option, several spellings: CSS wants `custom-colors`, JS wants
+// `customColors`, and Prettier turns either into `customcolors` on its way
+// through a stylesheet. Fold them all before reading.
+const OPTION_KEYS = ["prefix", "customColors", "shades"] as const;
+
+function normalizeOptions(options: MtbPluginOptions = {}) {
+  const fold = (key: string) => key.replaceAll("-", "").toLowerCase();
+  const canonical = new Map(OPTION_KEYS.map((key) => [fold(key), key]));
+
+  const normalized: MtbPluginOptions = {};
+  for (const [key, value] of Object.entries(options)) {
+    const name = canonical.get(fold(key));
+    if (!name) {
+      throw new Error(
+        `Unknown option '${key}' for the material-theme-builder Tailwind plugin. Expected one of: ${OPTION_KEYS.join(", ")}.`,
+      );
+    }
+    Object.assign(normalized, { [name]: value });
+  }
+
+  return normalized;
+}
+
+/**
+ * Build the Tailwind color theme backing the M3 color system.
+ *
+ * Every entry points at a `--{prefix}-sys-color-*` or `--{prefix}-ref-palette-*`
+ * custom property rather than a literal color, so the whole theme re-resolves
+ * whenever those change — which is what `<Mtb>` does at runtime.
+ *
+ * Exported for tests and for anyone assembling their own Tailwind config; the
+ * plugin's default export is the thing to reach for.
+ */
+export function mtbColors(options: MtbPluginOptions = {}) {
+  const {
+    prefix = DEFAULT_PREFIX,
+    shades: withShades = true,
+    customColors,
+  } = normalizeOptions(options);
+
+  const sys = (token: string) => `var(--${prefix}-sys-color-${token})`;
+  const ref = (palette: string, tone: number) =>
+    `var(--${prefix}-ref-palette-${palette}-${tone})`;
+
+  const colors: Record<string, ColorValue> = {};
+
+  // Keep an existing single value reachable as the scale's `DEFAULT`, so
+  // `bg-primary` stays the scheme role and `bg-primary-500` becomes the tone.
+  const addShades = (name: string, palette: string) => {
+    if (!withShades) return;
+    const scale = Object.fromEntries(
+      SHADE_TO_TONE.map(([shade, tone]) => [shade, ref(palette, tone)]),
+    );
+    const current = colors[name];
+    colors[name] =
+      typeof current === "string" ? { DEFAULT: current, ...scale } : scale;
+  };
+
+  // ── Scheme tokens ──
+  for (const token of tokenNames) {
+    const kebab = kebabCase(token);
+    colors[kebab] = sys(kebab);
+  }
+
+  // ── Shades for core palettes ──
+  for (const palette of CORE_PALETTES) addShades(palette, palette);
+
+  // ── Custom colors ──
+  for (const name of toNameList(customColors)) {
+    const kebab = kebabCase(name);
+
+    // M3 spells custom colors kebab-case; the name the user wrote is accepted
+    // too (`bg-myCustomColor1` next to `bg-my-custom-color-1`), because that
+    // is the spelling the hand-written `@theme` block documented before this
+    // plugin existed.
+    for (const alias of new Set([kebab, name])) {
+      colors[alias] = sys(kebab);
+      colors[`on-${alias}`] = sys(`on-${kebab}`);
+      colors[`${alias}-container`] = sys(`${kebab}-container`);
+      colors[`on-${alias}-container`] = sys(`on-${kebab}-container`);
+      addShades(alias, kebab);
+    }
+  }
+
+  return colors;
+}
+
+/**
+ * Tailwind v4 plugin exposing the M3 color system as Tailwind colors.
+ *
+ * ```css
+ * @import "tailwindcss";
+ * @plugin "material-theme-builder/tailwind" {
+ *   custom-colors: brand, success;
+ * }
+ * ```
+ *
+ * Replaces the hand-written `@theme inline { --color-*: var(--md-sys-color-*) }`
+ * block: `bg-surface-container-high`, `text-on-primary-container`,
+ * `border-outline-variant` and the `50`…`950` shades all resolve to the
+ * variables `<Mtb>` (or `toCss()`) writes to the page.
+ */
+export default plugin.withOptions<MtbPluginOptions | undefined>(
+  () => () => {},
+  (options) => ({ theme: { extend: { colors: mtbColors(options) } } }),
+);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -30,9 +30,19 @@ export default defineConfig([
     dts: true,
     clean: true,
     onSuccess: async () => {
-      // Copy tailwind.css to dist
+      // Copy the stylesheets to dist
       copyFileSync("src/tailwind.css", "dist/tailwind.css");
+      copyFileSync("src/shadcn.css", "dist/shadcn.css");
     },
+  },
+  {
+    ...shared,
+    entryPoints: ["src/tailwind.ts"],
+    // The Tailwind plugin runs in the build, not in the app: `tailwindcss` is
+    // the host's, never bundled in.
+    external: [...shared.external, "tailwindcss"],
+    dts: true,
+    clean: false,
   },
   {
     ...shared,


### PR DESCRIPTION
Supersedes #167 (Tailwind half only, closed) — this one also covers shadcn.

## Tailwind

```css
@import "tailwindcss";
@plugin "material-theme-builder/tailwind" {
  custom-colors: myCustomColor1, myCustomColor2;
}
```

instead of the ~180-line `@theme inline { --color-*: var(--md-sys-color-*) }` block.

Custom colors are the part a stylesheet could never cover — their names live in the app, not in the package — so they were exactly the manual step the README kept warning about ("Do not forget to manually add your custom colors"). Each one registers its four M3 roles and its shades, under both spellings: `bg-myCustomColor1` (what the README documented) and `bg-my-custom-color-1` (what `toTailwind()` emits).

Options: `prefix` (default `md`), `custom-colors`, `shades` (default `true` — off leaves Tailwind's own `neutral-*` alone). Read case- and dash-insensitively, because Prettier lowercases CSS declaration names and would otherwise turn a user's `customColors:` into `customcolors:` on save. An unknown option throws rather than silently doing nothing.

## shadcn

```css
@import "material-theme-builder/shadcn.css";
```

instead of the 31-line `:root, .dark { … }` block. The file already existed in `src/`, it just wasn't exported.

It stays a stylesheet rather than an option on the plugin, on purpose: a plugin can only reach `@layer base`, and shadcn's own `:root`/`.dark` are unlayered — layered styles lose to unlayered ones whatever their specificity, so a `shadcn: true` option would have been a silent no-op on a default shadcn `globals.css`. The "import it after" note stays, for that same cascade reason.

Same reason behind a caveat now documented: for the color names shadcn and M3 share (`primary`, `secondary`, `background`), shadcn's `@theme inline` beats the plugin's theme whatever the order — Tailwind gives a CSS `@theme` precedence over a plugin's. Those utilities keep shadcn's semantics, which `shadcn.css` has already pointed at M3.

## Also

- token names move to `src/lib/tokens.ts`, so the plugin — which runs inside the CSS build — reads them without pulling Material Color Utilities in (`dist/tailwind.js` is 7 KB, no runtime dep). Re-exported from `builder.ts`; public surface unchanged.
- `tailwind.css` keeps working and gains the two roles it was missing: `--color-surface-tint`, `--color-surface-variant` — found by a new test holding the shipped stylesheets against what the plugin registers.
- another test holds the plugin against `toTailwind()`, name for name, so the two spellings of the theme can't drift.
- `tailwindcss` added as an optional peer dep.

## Verified

`pnpm run lgtm` green (72 tests). Beyond unit tests, the built `dist/` was run through a real `@tailwindcss/postcss` build: utilities, tonal shades, opacity modifiers (`bg-primary/50`), custom colors in both spellings, and a shadcn-shaped `globals.css` where `--background` ends up resolving to `--md-sys-color-surface`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
