### PR TITLE
refactor!: drop `shadcn-init`, make `shadcn-apply` a plain forwarder

### DIFF
--- a/.changeset/plain-forwarder.md
+++ b/.changeset/plain-forwarder.md
@@ -37,3 +37,7 @@ Everything after a `--` now goes to `shadcn add` untouched, with no exception:
 The theme options (`--scheme`, `--contrast`, the color overrides, `--prefix`,
 `--no-fallback`) are unchanged, and so is `--format registry-item` for piping it
 somewhere else yourself.
+
+Unrelated to shadcn, and in this release because it is breaking too:
+`--format` now declares its own list, so `--format bananas` is refused by name
+instead of silently producing JSON.

--- a/.changeset/plain-forwarder.md
+++ b/.changeset/plain-forwarder.md
@@ -1,0 +1,39 @@
+---
+"material-theme-builder": major
+---
+
+`shadcn-init` is removed, and `shadcn-apply` is a plain forwarder.
+
+`shadcn-init` scaffolded a shadcn app, themed it and started its dev server.
+Three jobs, and only the middle one was ours — scaffolding is what
+`shadcn init` already does, better and with its own eighteen options, and
+starting a dev server is not a theming tool's business. Everything it needed to
+hold those together (a default `--preset b0 --template vite`, a merge that
+injected them only where you had not, reading the project name back out of the
+merged argv to know where to `cd`) went with it:
+
+```sh
+# before
+$ npx material-theme-builder shadcn-init "#6750A4"
+
+# now
+$ npx shadcn@latest init --preset b0 --template vite
+$ cd material-theme-app && npx material-theme-builder shadcn-apply "#6750A4"
+```
+
+`shadcn-apply` is unchanged in what it does — generate a registry item for your
+source color, `shadcn add` it, delete it — and simpler in how it treats you.
+Everything after a `--` now goes to `shadcn add` untouched, with no exception:
+
+- `--print` is gone. It rendered the chain as a shell one-liner instead of
+  running it, and required describing that chain as data so the two could not
+  disagree. On a single `shadcn add`, there is nothing left to disagree about.
+- An option of ours written after the `--` is no longer refused with an
+  explanation. It is forwarded, and shadcn answers for it. "Everything after the
+  separator is shadcn's" is now true without an asterisk.
+- `--shadcn-cli` no longer validates its argument. Whatever `npx` resolves,
+  it runs.
+
+The theme options (`--scheme`, `--contrast`, the color overrides, `--prefix`,
+`--no-fallback`) are unchanged, and so is `--format registry-item` for piping it
+somewhere else yourself.

--- a/README.md
+++ b/README.md
@@ -231,35 +231,24 @@ One command, from inside your project:
 $ npx material-theme-builder shadcn-apply "#6750A4"
 ```
 
-Or from nothing at all — `shadcn-init` scaffolds a stock shadcn app
-(`shadcn init --preset b0 --template vite`), themes it and starts it:
+From nothing at all, scaffold with shadcn's own CLI first — this is what the repo
+itself dogfoods:
 
 ```sh
-$ npx material-theme-builder shadcn-init "#6750A4"
+$ npx shadcn@latest init --preset b0 --template vite
+$ cd material-theme-app && npx material-theme-builder shadcn-apply "#6750A4"
 ```
 
-The verbs are shadcn's own — there, `init` is the new project and `apply` the
-existing one — and they are prefixed because shadcn is one integration here
-among Figma, CSS, Tailwind and Flutter: a bare `init` would read as "initialize
-material-theme-builder", and would leave no room for a `tailwind-init` later.
-
-Anything after a `--` is forwarded verbatim to the shadcn command underneath —
-`shadcn init` for `shadcn-init`, `shadcn add` for `shadcn-apply` — so
-`shadcn-init "#6750A4" -- --template next -n my-app` scaffolds Next instead.
-Options of ours go before the separator; one written after it is refused, rather
-than forwarded into an error from shadcn about a flag it has never heard of.
-`--print` writes the equivalent shell chain and runs nothing.
+Anything after a `--` is forwarded verbatim to `shadcn add` underneath, without
+exception — `shadcn-apply "#6750A4" -- --overwrite --dry-run`. Options of ours go
+before the separator.
 
 `--shadcn-cli <spec>` pins which shadcn runs — `--shadcn-cli shadcn@4.18.0`, a
 tag, a fork, anything `npx` resolves — defaulting to `shadcn@latest`. (Not
 `--shadcn`: the root command has used that name since 3.2.0 for something else
-entirely, a boolean that appends the alias block to `--format tailwind`.) It
-reaches for neighbouring versions rather than back in time, though: the defaults
-these commands pass are shadcn 4.x vocabulary (`--preset b0` is a 4.x preset
-code), so pinning far enough back also means passing that era's preset after the
-`--`.
+entirely, a boolean that appends the alias block to `--format tailwind`.)
 
-Both do the same two things by hand, if you would rather: generate a registry
+It does the same two things by hand, if you would rather: generate a registry
 item for your source color, and install it the way you install any shadcn theme.
 
 ```sh
@@ -288,15 +277,15 @@ So it works both ways round: live under an `<Mtb>`, and static — server-render
 zero client JS — anywhere there is none.
 
 Every option lands in those fallbacks, `--scheme` and `--contrast` included, and
-`shadcn-init` and `shadcn-apply` take them all — so the item they generate is the one the
-by-hand route would have produced:
+`shadcn-apply` takes them all — so the item it generates is the one the by-hand
+route would have produced:
 
 ```sh
 $ npx material-theme-builder shadcn-apply "#6750A4" --scheme vibrant --contrast 0.5
 ```
 
-`--no-fallback` leaves the fallbacks out, on all three. `--custom-colors` is the
-one option the two subcommands do not take, and that is not an oversight:
+`--no-fallback` leaves the fallbacks out, on both. `--custom-colors` is the one
+option the subcommand does not take, and that is not an oversight:
 shadcn's variable set is fixed, so no component reads a custom color and a
 registry item cannot carry one.
 

--- a/src/cli.options.ts
+++ b/src/cli.options.ts
@@ -1,13 +1,10 @@
 // The color-theme options -- the ones that describe *a theme* rather than what
-// to do with it -- declared once, and read back for two purposes.
+// to do with it -- declared once, and read back where they are needed.
 //
-// They were inline on the root command until three commands needed them: the
-// root command, `shadcn-init` and `shadcn-apply` all end up calling `builder()`.
-// Written out
-// three times, one copy would be a release behind the others, and eleven
-// descriptions is exactly the kind of thing nobody re-reads. `--print` gives the
-// subcommands a second reason to know the list rather than just declare it: the
-// chain it prints has to re-spell whatever was given.
+// They were inline on the root command until two commands needed them: the root
+// command and `shadcn-apply` both end up calling `builder()`. Written out twice,
+// one copy would be a release behind the other, and eleven descriptions is
+// exactly the kind of thing nobody re-reads.
 //
 // `--custom-colors` is deliberately *not* one of them. shadcn's variable set is
 // fixed, so no component reads a custom color and a registry item cannot carry
@@ -16,9 +13,9 @@
 // does nothing would be worse than a missing one.
 
 import {
-  Command,
   InvalidArgumentError,
   Option,
+  type Command,
   type OptionValues,
 } from "commander";
 
@@ -72,19 +69,11 @@ export function addSourceArgument(command: Command) {
 /** The `builder()` argument, minus the parts the CLI assembles separately. */
 export type ThemeOptions = Omit<MtbConfig, "source" | "customColors">;
 
-/**
- * Everything a registry item is generated from, in both forms the chain needs:
- * what `builder()` is handed, and how to say the same thing in a shell.
- */
+/** Everything a registry item is generated from. */
 export type Theme = {
   options: ThemeOptions;
   /** Whether the item bakes this theme's colors in as the `var()` fallbacks. */
   fallback: boolean;
-  /**
-   * The options as `--print` re-spells them — only the ones actually given, a
-   * printed line restating every default being noise rather than information.
-   */
-  args: string[];
 };
 
 /**
@@ -127,17 +116,12 @@ export function addThemeOptions(command: Command) {
     );
 }
 
-// What counts as a theme option, asked of a throwaway command rather than
-// written down a second time: the answer is whatever `addThemeOptions()`
-// declares, and a list that cannot be edited on its own cannot fall behind.
-const THEME_OPTIONS = addThemeOptions(new Command()).options;
-
 /**
  * The `builder()` argument, from parsed CLI options.
  *
  * Spelled out rather than passed through wholesale: commander's option bag also
- * carries `--format`, `--print` and the rest, and `builder()` should be handed
- * what it takes and nothing else.
+ * carries `--format` and the rest, and `builder()` should be handed what it
+ * takes and nothing else.
  */
 export function builderOptions(opts: OptionValues): ThemeOptions {
   return {
@@ -151,30 +135,6 @@ export function builderOptions(opts: OptionValues): ThemeOptions {
     neutralVariant: opts.neutralVariant,
     prefix: opts.prefix,
   };
-}
-
-/**
- * The theme options actually given on the command line, re-spelled as argv.
- *
- * `getOptionValueSource()` is what separates "given" from "defaulted" —
- * commander records where each value came from, and only `"cli"` is the user
- * saying so. Without it, `--print` would show a line restating every default,
- * which reads as though they had been asked for.
- */
-export function specifiedThemeArgs(command: Command) {
-  const args: string[] = [];
-
-  for (const option of THEME_OPTIONS) {
-    const name = option.attributeName();
-
-    if (command.getOptionValueSource(name) !== "cli") continue;
-    if (option.long) args.push(option.long);
-    // `--no-fallback` is a negation: the flag is the whole statement, and there
-    // is no `--fallback` to spell the other way round.
-    if (!option.negate) args.push(String(command.opts()[name]));
-  }
-
-  return args;
 }
 
 /**
@@ -192,6 +152,5 @@ export function themeFrom(command: Command): Theme {
     // which is what makes baking its colors in as the fallbacks free. See
     // `buildShadcnRegistryItem()`.
     fallback: opts.fallback ?? true,
-    args: specifiedThemeArgs(command),
   };
 }

--- a/src/cli.shadcn.test.ts
+++ b/src/cli.shadcn.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { addThemeOptions, themeFrom } from "./cli.options";
-import { addArgv, addChainOptions } from "./cli.shadcn";
+import { addArgv } from "./cli.shadcn";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -61,7 +61,7 @@ describe("addArgv()", () => {
 
 describe("theme options", () => {
   const command = (argv: string[]) => {
-    const parsed = addChainOptions(addThemeOptions(new Command()));
+    const parsed = addThemeOptions(new Command());
     parsed.parse(argv, { from: "user" });
     return parsed;
   };
@@ -129,6 +129,14 @@ describe("cli", () => {
     ["--scheme vibrant", ["--scheme", "vibrant", "--format", "css"], ":root {"],
   ] as const)("should still answer `%s`", (_, args, expected) => {
     expect(run(["#6750A4", ...args])).toContain(expected);
+  });
+
+  it.runIf(fs.existsSync(cli))("should refuse an unknown --format", () => {
+    // It used to fall through to JSON, silently -- a typo answered with output
+    // that looked like a deliberate choice.
+    expect(() => run(["#6750A4", "--format", "bananas"])).toThrow(
+      /Allowed choices are json, css, figma, tailwind, shadcn, registry-item, flutter/,
+    );
   });
 
   it.runIf(fs.existsSync(cli))(
@@ -199,7 +207,7 @@ describe("cli", () => {
   it.runIf(fs.existsSync(cli))(
     "should not claim our own options back from after the `--`",
     () => {
-      const parsed = addChainOptions(addThemeOptions(new Command()))
+      const parsed = addThemeOptions(new Command())
         .argument("<source>")
         .argument("[shadcn-args...]");
       parsed.parse(["#769CDF", "--", "--scheme", "vibrant"], { from: "user" });

--- a/src/cli.shadcn.test.ts
+++ b/src/cli.shadcn.test.ts
@@ -1,4 +1,4 @@
-import { Command, Option } from "commander";
+import { Command } from "commander";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -6,387 +6,88 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { addThemeOptions, themeFrom } from "./cli.options";
-import {
-  addChainOptions,
-  applyPlan,
-  chainOptionsFrom,
-  initPlan,
-  mergeDefaults,
-  ownOptionIn,
-  renderChain,
-  type Plan,
-  type Step,
-} from "./cli.shadcn";
+import { addArgv, addChainOptions } from "./cli.shadcn";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
-/**
- * The options `shadcn init` would be spawned with — the merged list, without the
- * `npx --yes shadcn@latest init` in front of it.
- */
-const initArgs = (forwarded: string[] = []) => {
-  const argv = spawnArgv(initPlan("#769CDF", forwarded))[0] ?? [];
-  return argv.slice(argv.indexOf("init") + 1);
+/** The args `shadcn add` is really spawned with, past its own name. */
+const added = (forwarded: string[] = []) => {
+  const argv = addArgv("shadcn@latest", forwarded);
+  return argv.slice(argv.indexOf("add") + 1);
 };
 
-/** Every `spawn` step's argv, in order. */
-const spawnArgv = (plan: Plan) =>
-  plan.steps
-    .filter(
-      (step): step is Extract<Step, { kind: "spawn" }> => step.kind === "spawn",
-    )
-    .map((step) => step.argv);
-
-describe("shadcn-init › forwarded args", () => {
-  it("should inject every default when nothing is forwarded", () => {
-    expect(initArgs()).toEqual([
-      "--preset",
-      "b0",
-      "--template",
-      "vite",
-      "--name",
-      "material-theme-app",
-      "--yes",
-    ]);
-  });
-});
-
-// The table the merge exists for: either spelling of an option the user
-// forwarded has to suppress our default for it, or shadcn is handed two.
-describe.each([
-  ["--name", "-n", "material-theme-app"],
-  ["--template", "-t", "vite"],
-  ["--preset", "-p", "b0"],
-] as const)("shadcn-init › %s", (long, short, ourValue) => {
-  it.each([
-    [`${long} mine`, [long, "mine"]],
-    [`${short} mine`, [short, "mine"]],
-    [`${long}=mine`, [`${long}=mine`]],
-  ])("should keep only the user's, given %s", (_, forwarded) => {
-    const args = initArgs(forwarded);
-    const spellings = args.filter(
-      (arg) => arg === long || arg === short || arg.startsWith(`${long}=`),
-    );
-
-    expect(spellings).toHaveLength(1);
-    expect(args).not.toContain(ourValue);
-    expect(args.slice(-forwarded.length)).toEqual(forwarded);
-  });
-});
-
-describe("shadcn-init › --yes", () => {
-  it.each([["--yes"], ["-y"]])(
-    "should not be injected twice, given %s",
-    (spelling) => {
-      expect(
-        initArgs([spelling]).filter((arg) => arg === spelling),
-      ).toHaveLength(1);
-      expect(initArgs([spelling])).not.toContain(
-        spelling === "-y" ? "--yes" : "-y",
-      );
-    },
-  );
-});
-
-describe("shadcn-init › unrelated flags", () => {
-  it("should forward them untouched, suppressing no default", () => {
-    const args = initArgs(["--rtl"]);
-
-    expect(args).toEqual([
-      "--preset",
-      "b0",
-      "--template",
-      "vite",
-      "--name",
-      "material-theme-app",
-      "--yes",
-      "--rtl",
-    ]);
-  });
-});
-
-describe("shadcn-init › the scaffold directory", () => {
-  it.each([
-    ["nothing forwarded", [], "material-theme-app"],
-    ["-n mine", ["-n", "mine"], "mine"],
-    ["--name mine", ["--name", "mine"], "mine"],
-    ["--name=mine", ["--name=mine"], "mine"],
-    // A value attached to a short flag: commander accepts it, so the chain has
-    // to `cd` into what shadcn will really create.
-    ["-nmine", ["-nmine"], "mine"],
-    // Last one wins, as commander reads a repeated option.
-    ["two names", ["-n", "first", "--name", "second"], "second"],
-  ] as const)("should be %s → %s", (_, forwarded, dir) => {
-    expect(initPlan("#769CDF", [...forwarded]).dir).toBe(dir);
-  });
-});
-
-describe("shadcn-apply", () => {
-  it("should inject -y and forward the rest to `shadcn add`", () => {
-    const [argv] = spawnArgv(applyPlan("#769CDF", ["--overwrite"]));
-
-    expect(argv).toEqual([
+describe("addArgv()", () => {
+  it("should run the pinned shadcn under npx", () => {
+    expect(addArgv("shadcn@4.18.0").slice(0, 4)).toEqual([
       "npx",
       "--yes",
-      "shadcn@latest",
+      "shadcn@4.18.0",
       "add",
+    ]);
+  });
+
+  it("should install the generated item by relative path", () => {
+    // `shadcn add` decides between a local file and a registry name on
+    // `endsWith(".json") && !isURL(path)`, so the `./` and the extension are
+    // both load-bearing.
+    expect(added()[0]).toBe("./mtb.json");
+  });
+
+  it("should pass --yes, which shadcn add defaults to false", () => {
+    // Without it, `shadcn add` prompts on a `registry:theme` item and the
+    // command hangs in CI.
+    expect(added()).toContain("--yes");
+  });
+
+  it("should forward everything after the `--`, verbatim and in order", () => {
+    expect(added(["--overwrite", "-p", "src/app", "--dry-run"])).toEqual([
       "./mtb.json",
       "--yes",
       "--overwrite",
+      "-p",
+      "src/app",
+      "--dry-run",
     ]);
   });
 
-  it("should not inject -y twice", () => {
-    // Sliced past `add ./mtb.json`, so that `npx --yes` is not mistaken for one
-    // of the options being counted.
-    const [argv = []] = spawnArgv(applyPlan("#769CDF", ["-y"]));
-    const options = argv.slice(argv.indexOf("add") + 2);
+  it("should put --yes ahead of the forwarded args, so they can win", () => {
+    // Both CLIs are commander, which takes the last occurrence of a repeated
+    // option -- which is what makes a forwarded `--no-yes` work.
+    const args = added(["--no-yes"]);
 
-    expect(options).toEqual(["-y"]);
-  });
-
-  it("should neither scaffold nor start anything", () => {
-    const plan = applyPlan("#769CDF");
-
-    expect(plan.dir).toBeUndefined();
-    expect(plan.steps.map((step) => step.kind)).toEqual([
-      "item",
-      "spawn",
-      "rm",
-    ]);
+    expect(args.indexOf("--yes")).toBeLessThan(args.indexOf("--no-yes"));
   });
 });
-
-describe("mergeDefaults()", () => {
-  it("should put ours first, so a duplicate it misses still wins downstream", () => {
-    const merged = mergeDefaults(
-      [{ long: "--name", short: "-n", value: "ours" }],
-      ["--no-name"],
-    );
-
-    expect(merged).toEqual(["--name", "ours", "--no-name"]);
-  });
-});
-
-describe("ownOptionIn()", () => {
-  const declared = [
-    new Option("--print", "print"),
-    new Option("--scheme <name>", "scheme"),
-    new Option("--no-fallback", "no fallback"),
-  ];
-
-  // Ours after the `--` is a mistake worth a message, not something to
-  // reinterpret: forwarded verbatim it would come back as an unknown-option
-  // error from shadcn, about a flag shadcn has never heard of.
-  it.each([
-    ["--print", ["-n", "mine", "--print"], "--print"],
-    ["--scheme", ["--scheme", "vibrant"], "--scheme"],
-    ["--scheme=value", ["--scheme=vibrant"], "--scheme=vibrant"],
-    // Declared as a negation, so the flag as typed is what has to be matched.
-    ["--no-fallback", ["--no-fallback"], "--no-fallback"],
-  ])("should find %s among the forwarded args", (_, forwarded, found) => {
-    expect(ownOptionIn(declared, forwarded)).toBe(found);
-  });
-
-  it.each([
-    ["shadcn's own options", ["-n", "mine", "--rtl", "--overwrite"]],
-    ["nothing at all", []],
-  ])("should pass %s through", (_, forwarded) => {
-    expect(ownOptionIn(declared, forwarded)).toBeUndefined();
-  });
-});
-
-// A subcommand wired the way `cli.ts` wires one, parsed with `argv`.
-//
-// Declared under a program that also carries the theme options, because that is
-// the arrangement: the same names on the program and on the subcommand, and
-// positional options as the only thing that stops the program from matching
-// `--scheme` first and handing the subcommand a default theme.
-function themeCommand(argv: string[]) {
-  let captured: Command | undefined;
-
-  const program = addThemeOptions(
-    new Command().argument("<source>"),
-  ).enablePositionalOptions();
-
-  addChainOptions(
-    addThemeOptions(
-      program
-        .command("shadcn-apply")
-        .argument("<source>")
-        .argument("[shadcn-args...]"),
-    ),
-  ).action((_source, _args, _opts, command: Command) => {
-    captured = command;
-  });
-
-  program.parse(["shadcn-apply", "#769CDF", ...argv], { from: "user" });
-
-  if (!captured) throw new Error("the action never ran");
-
-  return captured;
-}
-
-/** `--flag value` pairs, and bare flags, read back out of an argv. */
-function parseFlags(args: string[]) {
-  const flags: Record<string, string | true> = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const flag = args[i] ?? "";
-    const next = args[i + 1];
-
-    if (next !== undefined && !next.startsWith("--")) {
-      flags[flag] = next;
-      i++;
-    } else {
-      flags[flag] = true;
-    }
-  }
-
-  return flags;
-}
-
-/** The `> mtb.json` step of a rendered chain. */
-const itemStep = (chain: string) =>
-  chain.split(" && ").find((step) => step.includes("--format registry-item"));
 
 describe("theme options", () => {
-  const given = ["--scheme", "vibrant", "--contrast", "0.5", "--prefix", "my"];
+  const command = (argv: string[]) => {
+    const parsed = addChainOptions(addThemeOptions(new Command()));
+    parsed.parse(argv, { from: "user" });
+    return parsed;
+  };
 
   it("should reach the subcommand rather than the program", () => {
     // The regression `enablePositionalOptions()` exists for: the same option
     // names are declared on both, and only one of them is being asked.
-    expect(themeFrom(themeCommand(given)).options.scheme).toBe("vibrant");
+    const theme = themeFrom(command(["--scheme", "vibrant", "--prefix", "my"]));
+
+    expect(theme.options.scheme).toBe("vibrant");
+    expect(theme.options.prefix).toBe("my");
   });
 
-  // The pair that can silently diverge now that both exist: what `--print`
-  // re-spells, and what the runner hands `builder()`. Checked against each other,
-  // not each against a literal.
-  it("should describe the same theme they generate", () => {
-    const theme = themeFrom(themeCommand([...given, "--no-fallback"]));
-    const spelled = parseFlags(theme.args);
-
-    expect(spelled["--scheme"]).toBe(theme.options.scheme);
-    expect(Number(spelled["--contrast"])).toBe(theme.options.contrast);
-    expect(spelled["--prefix"]).toBe(theme.options.prefix);
-    expect("--no-fallback" in spelled).toBe(!theme.fallback);
-    expect(theme.fallback).toBe(false);
-  });
-
-  it("should carry into the printed item step, ahead of --format", () => {
-    const theme = themeFrom(themeCommand([...given, "--no-fallback"]));
-
-    expect(itemStep(renderChain(applyPlan("#769CDF", [], { theme })))).toBe(
-      "npx --yes material-theme-builder '#769CDF' --scheme vibrant --contrast 0.5 --no-fallback --prefix my --format registry-item > mtb.json",
-    );
-  });
-
-  it("should leave --shadcn-cli out of the item step", () => {
-    // That line generates the registry item; which shadcn installs it is a
-    // question about the step after.
-    const theme = themeFrom(themeCommand(given));
-    const plan = applyPlan("#769CDF", [], { theme, shadcn: "shadcn@4.18.0" });
-
-    expect(itemStep(renderChain(plan))).toBe(
-      "npx --yes material-theme-builder '#769CDF' --scheme vibrant --contrast 0.5 --prefix my --format registry-item > mtb.json",
-    );
-  });
-
-  it("should render nothing when none was given", () => {
-    // A printed line restating every default would read as though the defaults
-    // had been asked for.
-    const theme = themeFrom(themeCommand([]));
-
-    expect(theme.args).toEqual([]);
-    expect(theme.fallback).toBe(true);
-    expect(theme.options.scheme).toBe("tonalSpot");
-    expect(itemStep(renderChain(applyPlan("#769CDF", [], { theme })))).toBe(
-      "npx --yes material-theme-builder '#769CDF' --format registry-item > mtb.json",
-    );
-  });
-});
-
-// The anti-drift check: `--print` is only trustworthy if it cannot describe
-// something other than what the runner would do. Both read one `Plan`, so it is
-// enough to assert every spawned argv appears in the printed line, verbatim.
-describe.each([
-  ["shadcn-init", initPlan],
-  ["shadcn-apply", applyPlan],
-] as const)("renderChain() › %s", (_, plan) => {
-  it("should contain the argv of every step it would spawn", () => {
-    const built = plan("#769CDF", ["-n", "my app"]);
-    const line = renderChain(built);
-
-    for (const argv of spawnArgv(built)) {
-      // `my app` needs quoting to survive a shell, and so does the color's `#`
-      // -- the point is that every token is there, in order, in one piece.
-      expect(line).toContain(
-        argv
-          .map((arg) => (/^[\w@%+=:,./-]+$/.test(arg) ? arg : `'${arg}'`))
-          .join(" "),
-      );
-    }
-
-    expect(line).toContain("'#769CDF'");
-  });
-});
-
-describe("renderChain() › init", () => {
-  it("should read as the chain the README documents", () => {
-    expect(renderChain(initPlan("#769CDF"))).toBe(
-      "npx --yes shadcn@latest init --preset b0 --template vite --name material-theme-app --yes && " +
-        "cd material-theme-app && " +
-        "npx --yes material-theme-builder '#769CDF' --format registry-item > mtb.json && " +
-        "npx --yes shadcn@latest add ./mtb.json --yes && " +
-        "rm mtb.json && " +
-        "npm run dev",
-    );
-  });
-});
-
-/** The `npx` package spec each shadcn spawn of a plan runs, in order. */
-const shadcnSpecs = (plan: Plan) =>
-  spawnArgv(plan)
-    .filter(([command]) => command === "npx")
-    .map((argv) => argv[2]);
-
-describe("--shadcn-cli <spec>", () => {
-  const pinned = { shadcn: "shadcn@4.18.0" };
-
-  // Both of init's, not just the scaffold: a chain pinned for `init` and floating
-  // for the `add` that installs into it is worse than one that floats throughout.
-  it("should pin every shadcn spawn of the chain", () => {
-    expect(shadcnSpecs(initPlan("#769CDF", [], pinned))).toEqual([
-      "shadcn@4.18.0",
-      "shadcn@4.18.0",
-    ]);
-    expect(shadcnSpecs(applyPlan("#769CDF", [], pinned))).toEqual([
-      "shadcn@4.18.0",
-    ]);
-  });
-
-  it("should default to shadcn@latest", () => {
-    expect(shadcnSpecs(initPlan("#769CDF"))).toEqual([
-      "shadcn@latest",
-      "shadcn@latest",
-    ]);
-    expect(chainOptionsFrom(themeCommand([])).shadcn).toBe("shadcn@latest");
-  });
-
-  it("should be read off the command", () => {
-    expect(
-      chainOptionsFrom(themeCommand(["--shadcn-cli", "shadcn@next"])).shadcn,
-    ).toBe("shadcn@next");
+  it("should default `fallback` to true, being declared as a negation", () => {
+    expect(themeFrom(command([])).fallback).toBe(true);
+    expect(themeFrom(command(["--no-fallback"])).fallback).toBe(false);
   });
 });
 
 // The built binary, on the invocations that have to keep behaving exactly as
-// they did before the subcommands existed. Offline and fast -- the chains
-// themselves reach the network, so they are never run here.
-describe("cli › backward compatibility", () => {
+// they did. Offline and fast -- the chain itself reaches the network, so it is
+// never run here.
+describe("cli", () => {
   const cli = path.join(here, "..", "dist", "cli.js");
-  // stderr piped rather than inherited, so the two guard messages below land in
-  // the thrown error instead of in the suite's own output.
+  // stderr piped rather than inherited, so the guard messages below land in the
+  // thrown error instead of in the suite's own output.
   const run = (args: string[]) =>
     execFileSync(process.execPath, [cli, ...args], {
       encoding: "utf8",
@@ -413,8 +114,8 @@ describe("cli › backward compatibility", () => {
       ["--format", "registry-item", "--no-fallback"],
       '"card": "var(--md-sys-color-surface-container-low)"',
     ],
-    // The one theme option the subcommands deliberately do not have, so the only
-    // place it can be checked is here.
+    // The one theme option the subcommand deliberately does not have, so the
+    // only place it can be checked is here.
     [
       "--custom-colors",
       [
@@ -472,79 +173,39 @@ describe("cli › backward compatibility", () => {
     expect(message).not.toContain("node_modules");
   });
 
-  it.runIf(fs.existsSync(cli))("should list the subcommands in --help", () => {
+  it.runIf(fs.existsSync(cli))("should list the subcommand in --help", () => {
     const help = run(["--help"]);
 
-    expect(help).toContain("shadcn-init");
     expect(help).toContain("shadcn-apply");
     expect(help).toContain("<source>");
+    // Removed in 4.0.0 -- `shadcn init` is shadcn's to run.
+    expect(help).not.toContain("shadcn-init");
   });
 
-  // Through the binary because the message has to name the flag the user really
-  // typed and the shadcn command it would really have gone to, and only a full
-  // parse knows both. Offline: it refuses before spawning anything.
-  it.runIf(fs.existsSync(cli)).each([
-    [
-      "shadcn-init",
-      ["shadcn-init", "#769CDF", "--", "--print"],
-      "--print",
-      "shadcn init",
-    ],
-    [
-      "shadcn-apply",
-      ["shadcn-apply", "#769CDF", "--", "--scheme", "vibrant"],
-      "--scheme",
-      "shadcn add",
-    ],
-    // `--print` was given on the wrong side of the separator, so the refusal is
-    // about `--print` -- not a chain that prints, and not a crash.
-    [
-      "shadcn-apply, mixed with a real shadcn flag",
-      ["shadcn-apply", "#769CDF", "--", "--overwrite", "--print"],
-      "--print",
-      "shadcn add",
-    ],
-    // Covered by the same check without it being taught about `--shadcn-cli`,
-    // which is the point of reading the declarations rather than a list -- and
-    // covered under the new name only, the subcommand having no `--shadcn` of its
-    // own to claim.
-    [
-      "shadcn-apply, --shadcn-cli",
-      ["shadcn-apply", "#769CDF", "--", "--shadcn-cli", "shadcn@4.18.0"],
-      "--shadcn-cli",
-      "shadcn add",
-    ],
-  ] as const)(
-    "should refuse an option of ours after the `--` (%s)",
-    (_, args, flag, target) => {
-      expect(() => run([...args])).toThrow(
-        `${flag} is ours, not shadcn's, so it belongs before the \`--\`. Everything after the separator is handed to \`${target}\` untouched.`,
-      );
+  // The unprefixed name, which is what habit from every other CLI will type.
+  // There is no subcommand to route it to, so it reaches the root command as its
+  // `<source>`, where the color that follows is one operand too many. An error
+  // is the whole point: a theme built from the word "apply" would be worse.
+  it.runIf(fs.existsSync(cli))(
+    "should not quietly read `apply` as a source color",
+    () => {
+      expect(() => run(["apply", "#769CDF"])).toThrow(/too many arguments/);
     },
   );
 
-  // The unprefixed names, which is what habit from every other CLI will type.
-  // There is no subcommand to route them to, so they reach the root command as
-  // its `<source>`, where the color that follows is one operand too many. An
-  // error is the whole point: a theme built from the word "init" would be worse.
-  it.runIf(fs.existsSync(cli)).each([["init"], ["apply"]])(
-    "should not quietly read `%s` as a source color",
-    (name) => {
-      expect(() => run([name, "#769CDF"])).toThrow(/too many arguments/);
+  // Everything after the separator is shadcn's, without exception -- including
+  // an option we happen to declare ourselves. Checked here because only a full
+  // parse proves commander does not claim it back.
+  it.runIf(fs.existsSync(cli))(
+    "should not claim our own options back from after the `--`",
+    () => {
+      const parsed = addChainOptions(addThemeOptions(new Command()))
+        .argument("<source>")
+        .argument("[shadcn-args...]");
+      parsed.parse(["#769CDF", "--", "--scheme", "vibrant"], { from: "user" });
+
+      expect(parsed.args.slice(1)).toEqual(["--scheme", "vibrant"]);
+      expect(parsed.opts().scheme).toBe("tonalSpot");
     },
   );
-
-  // The value reaches `npx` in the position where npx reads its own options, so
-  // these two are worth rejecting ourselves rather than letting npx fail at them
-  // several seconds later.
-  it.runIf(fs.existsSync(cli)).each([
-    ["a bare version", ["--shadcn-cli", "4.18.0"], "write 'shadcn@4.18.0'"],
-    [
-      "a leading dash",
-      ["--shadcn-cli", "--overwrite"],
-      "cannot start with '-'",
-    ],
-  ] as const)("should reject %s as a --shadcn-cli spec", (_, args, message) => {
-    expect(() => run(["shadcn-apply", "#769CDF", ...args])).toThrow(message);
-  });
 });

--- a/src/cli.shadcn.ts
+++ b/src/cli.shadcn.ts
@@ -1,588 +1,89 @@
-// The `shadcn-init` and `shadcn-apply` subcommands -- the two ways to get a
-// shadcn project themed from a source color.
+// The `shadcn-apply` subcommand: theme the shadcn project in the current
+// directory, from a source color.
 //
-// The verbs are shadcn's own, and so is the distinction they draw:
-//
-//   init|create   initialize your project and install dependencies   (new project)
-//   apply         apply a preset to an existing project              (existing project)
-//
-// https://ui.shadcn.com/create offers exactly that pair -- its "New Project"
-// button copies `shadcn init --preset b0 --template vite`, its "Existing
-// Project" button `shadcn apply --preset b0` -- so anyone arriving from there
-// already knows which of ours to reach for, where a verb of our own invention
-// ("try", "setup") would have been one more thing to learn.
-//
-// The prefix is because this is not a shadcn tool. The package emits Figma
-// tokens, CSS, Tailwind and Flutter as well; shadcn is one integration among
-// several. A bare `init` at the top level would therefore read as "initialize
-// material-theme-builder", which is not what it does -- and it would spend the
-// shared verb space on one integration, leaving nowhere sensible for a
-// `tailwind-init` later. Prefixed, the name carries both the verb and what it
-// targets, and it reads alongside `--shadcn-cli`.
-//
-// Both chains end in `shadcn add` on a registry item generated in-process for
-// the source color: that is the one gesture which rewrites the values inside a
-// project's existing `:root` and `.dark` blocks in place, rather than asking an
-// `@import` to win a cascade it is usually placed too early to win. See
-// `buildShadcnRegistryItem()`.
-//
-// Our `shadcn-apply` deliberately does *not* shell out to `shadcn apply`,
-// tempting as the symmetry is: that command applies shadcn *presets* -- a
-// different artifact with its own schema and its own `--only theme,font`
-// semantics -- and what we have is a `registry:theme` item, which only `shadcn
-// add` installs. The verb is borrowed; the mechanism stays `add`.
+// A forwarder, and nothing more. It generates a `registry:theme` item for the
+// source color, hands it to `shadcn add`, and deletes it. Everything written
+// after a `--` goes to `shadcn add` untouched, with no exception -- that being
+// the only rule about the separator anyone can hold.
 
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 
-import { InvalidArgumentError, type Command, type Option } from "commander";
-import { themeFrom, type Theme } from "./cli.options";
+import { type Command } from "commander";
+import { themeFrom } from "./cli.options";
 import { builder } from "./lib/builder";
 
 // Spawned rather than assumed installed, so a bare `npx material-theme-builder
-// shadcn-init` works with nothing on disk. `--yes` because the whole point is a
-// command that does not stop to ask.
+// shadcn-apply` works with nothing on disk.
 const NPX = ["npx", "--yes"];
 const DEFAULT_SHADCN = "shadcn@latest";
-const SELF = "material-theme-builder";
 
-// The shadcn command each chain ends up in, named once: it labels the step in an
-// error message, and it is what a refused option is told it would have gone to.
-const INIT_TARGET = "shadcn init";
-const ADD_TARGET = "shadcn add";
+// `shadcn add` defaults its own `--yes` to *false*, and prompts for
+// confirmation on a `registry:theme` item ("You are about to install a new
+// theme."). Without this the command is not scriptable and hangs in CI. Ours
+// goes first so a forwarded `--no-yes` still wins -- both CLIs are commander,
+// which takes the last occurrence of a repeated option.
+const YES = "--yes";
 
-// Where the generated registry item lands, relative to the project being
-// themed. `shadcn add` cannot read stdin -- it decides between a local file and
-// a registry name on `endsWith(".json") && !isURL(path)` -- so a real file with
-// a real `.json` name is not a matter of taste. `shadcn-apply` runs inside
-// someone's own project, hence a name unlikely to be theirs, and a check before
-// writing.
+// Where the generated registry item lands. `shadcn add` cannot read stdin -- it
+// decides between a local file and a registry name on `endsWith(".json") &&
+// !isURL(path)` -- so a real file with a real `.json` name is not a matter of
+// taste. This runs inside someone's own project, hence a name unlikely to be
+// theirs, and a check before writing.
 const ITEM = "mtb.json";
 
-// The directory `shadcn-init` scaffolds into, when the user names none. Named
-// after what it is rather than after the command that made it -- a directory
-// called `material-theme-shadcn-init` would be this CLI's own vocabulary showing
-// through into someone's file tree.
-const APP_NAME = "material-theme-app";
-
-/** A `shadcn` option we default, in both of the spellings it answers to. */
-type Defaulted = {
-  /** e.g. `--name` */
-  long: string;
-  /** e.g. `-n` */
-  short: string;
-  /** omitted for a boolean flag */
-  value?: string;
-};
-
-const NAME: Defaulted = { long: "--name", short: "-n", value: APP_NAME };
-const YES: Defaulted = { long: "--yes", short: "-y" };
-
-// `--preset b0` is the load-bearing default: with no preset, `shadcn init`
-// prompts for the component library even though its own `-y` already defaults to
-// true ("? Select a component library >  Base UI (Recommended)"), which would
-// hang the one-liner this command exists to be. `b0` is a preset *code* --
-// `shadcn preset decode b0` reads it back as Base UI, style nova, neutral base,
-// theme and chart colors, lucide, Inter, default radius -- so it picks the whole
-// style bundle, not just a name. None of that reaches our mapping, which rewrites
-// only the 31 standard color variables every preset writes; `b0` is simply the
-// preset this repo dogfoods.
-//
-// `--yes` is redundant against today's shadcn, where it already defaults to
-// true, and passed anyway: the printed chain has to stay non-interactive on its
-// own terms rather than on an upstream default that could move.
-//
-// Which also bounds how far back `--shadcn-cli <spec>` can usefully pin: this
-// list is shadcn 4.x vocabulary. Preset *codes* and `shadcn preset decode` are a
-// 4.x thing, so an older CLI would reject `--preset b0` outright. Pinning is an
-// escape hatch for the neighbouring versions, not a time machine -- travelling
-// further means passing a preset of that era after the `--` as well.
-const INIT_DEFAULTS: Defaulted[] = [
-  { long: "--preset", short: "-p", value: "b0" },
-  { long: "--template", short: "-t", value: "vite" },
-  NAME,
-  YES,
-];
-
-// `shadcn add` has no prompt worth pre-answering beyond confirmation, so this is
-// the whole list.
-const ADD_DEFAULTS: Defaulted[] = [YES];
-
-// ─── The chain's own options ─────────────────────────────────────────────
-
-// A spec is whatever `npx` will resolve -- a version, a tag, a fork, a tarball --
-// so this validates only the two ways it can be wrong beyond doubt. Anything else
-// is npx's business, and guessing at package names here would reject specs that
-// work.
-function parseShadcnSpec(value: string) {
-  // It lands in the argv position where npx reads its own options, so a leading
-  // dash would silently become one.
-  if (value.startsWith("-"))
-    throw new InvalidArgumentError(
-      "A package spec cannot start with '-': npx would read it as one of its own options.",
-    );
-
-  // The likely slip, and worth naming: a version alone resolves to nothing.
-  // Leading digit is the whole test -- deciding what is a package name is harder
-  // and buys nothing.
-  if (/^\d/.test(value))
-    throw new InvalidArgumentError(
-      `That is a version, not a package spec -- write 'shadcn@${value}'.`,
-    );
-
-  return value;
-}
-
 /**
- * Declare the options that describe the chain itself rather than the theme it
- * installs — which shadcn runs it, and whether it runs at all.
+ * Declare the options describing the run itself rather than the theme it
+ * installs.
  *
  * `--shadcn-cli` rather than the obvious `--shadcn`, which is taken: the root
  * command has shipped a boolean `--shadcn` since 3.2.0 (it appends the alias
- * block to `--format tailwind`). Positional options would in fact keep the two
- * apart, each command matching only what it declares — but one word meaning a
- * boolean here and a package spec there is a trap for whoever reads `--help`
- * twice, and the released one is the one that cannot move. So this is the name
- * that gave way; simplifying it back to `--shadcn` would be a breaking change to
- * a flag people already pass.
- *
- * An option at all, rather than a version in the subcommand name
- * (`shadcn-init@4.18.0`, the way `npm create vite@latest` reads): a name carrying
- * a spec means giving up commander's subcommand routing for a catch-all that
- * parses the name itself, and — the deciding cost — `--help` has nowhere to
- * mention that `@4.18.0` is allowed, where an option prints its own default on
- * the line beside it.
+ * block to `--format tailwind`).
  */
 export function addChainOptions(command: Command) {
-  return command
-    .option(
-      "--shadcn-cli <spec>",
-      "npx package spec for the shadcn CLI to run (a version, tag, fork or tarball — anything npx resolves)",
-      parseShadcnSpec,
-      DEFAULT_SHADCN,
-    )
-    .option(
-      "--print",
-      "Print the equivalent shell chain instead of running it",
-    );
-}
-
-// ─── Argument merging ────────────────────────────────────────────────────
-
-// Whether the forwarded args already spell an option, in either form. Both have
-// to count: `-n my-app` must suppress `--name`, or shadcn is handed two names
-// and the chain `cd`s into the wrong directory. A value attached to a short flag
-// (`-nmy-app`) counts too -- commander accepts it, so someone will write it.
-function mentions(args: string[], { long, short }: Defaulted) {
-  return args.some(
-    (arg) =>
-      arg === long || arg.startsWith(`${long}=`) || arg.startsWith(short),
+  return command.option(
+    "--shadcn-cli <spec>",
+    "npx package spec for the shadcn CLI to run (a version, tag, fork or tarball — anything npx resolves)",
+    DEFAULT_SHADCN,
   );
 }
 
 /**
- * Merge our defaults into the args forwarded after the `--`, flag by flag,
- * injecting each only where the user spelled none themselves.
+ * The argv for the `shadcn add` that installs the generated item.
  *
- * Not a mirror of shadcn's own options, deliberately: `shadcn init` has
- * eighteen, several of which collide with names we already use (`-p/--preset`
- * against our `--primary`), and redeclaring them would mean tracking their
- * majors. The `--` separator says "the rest is theirs", the POSIX way, and this
- * is the only thing we do to that side of it.
- *
- * Ours go first so that the user's win on any duplicate this fails to notice:
- * both CLIs are commander, and commander takes the last occurrence of a repeated
- * option. That is also what makes a forwarded `--no-yes` work -- unrecognized as
- * a spelling of `--yes`, injected against, and then overridden anyway.
+ * @param shadcn the npx package spec to run
+ * @param forwarded args given after the `--`
  */
-export function mergeDefaults(defaults: Defaulted[], forwarded: string[]) {
-  const injected = defaults
-    .filter((option) => !mentions(forwarded, option))
-    .flatMap(({ long, value }) =>
-      value === undefined ? [long] : [long, value],
-    );
-
-  return [...injected, ...forwarded];
+export function addArgv(shadcn: string, forwarded: string[] = []) {
+  return [...NPX, shadcn, "add", `./${ITEM}`, YES, ...forwarded];
 }
-
-// The name `shadcn init` will really use, read back off the merged args rather
-// than tracked alongside them -- the chain has to `cd` into the directory shadcn
-// actually creates. Scanning from the end mirrors commander's last-one-wins, and
-// covers the three ways to spell a value.
-function lastName(args: string[]) {
-  for (let i = args.length - 1; i >= 0; i--) {
-    const arg = args[i] ?? "";
-
-    if (arg === NAME.long || arg === NAME.short) return args[i + 1];
-    if (arg.startsWith(`${NAME.long}=`)) return arg.slice(NAME.long.length + 1);
-    if (arg.length > NAME.short.length && arg.startsWith(NAME.short))
-      return arg.slice(NAME.short.length);
-  }
-
-  return undefined;
-}
-
-/**
- * The first of `declared` found among the args forwarded after the `--`, as it
- * was written.
- *
- * A refusal, not a rescue. `shadcn-init '#x' -- --print` used to be read as
- * though the flag had been written before the separator, which made "everything
- * after `--` is theirs" true except once — and an except-once rule is one nobody
- * can hold.
- * Reading those args in order to *decline* them leaves the separator's meaning
- * exactly as it was; it is reinterpreting one of them that quietly redefined it.
- * The refusal also gets to say what to do, where the alternative is an
- * unknown-option error from shadcn three seconds later, about a flag it has never
- * heard of.
- *
- * Matched against what the subcommand declares rather than a list kept here, so
- * it covers every option either one gains without being edited — which is how
- * `-- --scheme vibrant` comes to be refused clearly rather than forwarded into a
- * confusing failure.
- *
- * The cost of making the rule absolute: if shadcn ever adds an option we also
- * declare, this refuses to forward it. Nothing collides today — none of
- * `--scheme`, `--contrast`, `--primary`, `--print` or the rest appears in
- * `shadcn init` or `shadcn add`. If one does, the fix is to rename ours, not to
- * soften this back into a special case.
- */
-export function ownOptionIn(declared: readonly Option[], forwarded: string[]) {
-  return forwarded.find((arg) =>
-    declared.some(
-      (option) =>
-        arg === option.long ||
-        arg === option.short ||
-        (option.long !== undefined && arg.startsWith(`${option.long}=`)),
-    ),
-  );
-}
-
-// "ours, not shadcn's" rather than naming this subcommand: since the rename, ours
-// is called `shadcn-init` and the thing on the far side of the separator is
-// `shadcn init`, and a sentence carrying both would ask the reader to tell two
-// nearly identical names apart in order to learn which owns the flag. Saying
-// whose it is answers that directly, and `${target}` still says where the rest
-// went.
-function refuseOwnOptions(
-  command: Command,
-  forwarded: string[],
-  target: string,
-) {
-  const misplaced = ownOptionIn(command.options, forwarded);
-
-  if (misplaced !== undefined)
-    fail(
-      `${misplaced} is ours, not shadcn's, so it belongs before the \`--\`. Everything after the separator is handed to \`${target}\` untouched.`,
-    );
-}
-
-// ─── The chain, as data ──────────────────────────────────────────────────
-
-/**
- * One step of a chain.
- *
- * `spawn` steps carry the argv verbatim -- no interpolation into a shell, the
- * source color and the forwarded args both being user input.
- */
-export type Step =
-  | { kind: "spawn"; label: string; argv: string[]; where: "cwd" | "project" }
-  | { kind: "cd"; dir: string }
-  | { kind: "item"; file: string }
-  | { kind: "rm"; file: string };
-
-/**
- * A chain: the steps in order, plus what the registry item is generated from.
- *
- * The one description both `--print` and the runner read, so the two cannot
- * disagree about what would happen -- which is the only thing that makes
- * `--print` trustworthy as an eject hatch.
- */
-export type Plan = {
-  /** The source color the registry item is generated from. */
-  source: string;
-  /** The theme options it is generated with. */
-  theme: Theme;
-  /** The directory this chain scaffolds and then works in, if it scaffolds one. */
-  dir?: string;
-  steps: Step[];
-};
-
-/**
- * What the invoked subcommand contributes to a chain, beyond the args it
- * forwards.
- *
- * Read off the command in one place, so a plan can be built in a test without
- * one.
- */
-export type ChainOptions = {
-  /** The theme the registry item is generated with. */
-  theme: Theme;
-  /** The `npx` package spec the shadcn steps run. */
-  shadcn: string;
-};
-
-// A theme asked for at every default -- what both plans describe when no theme
-// option was given, and what the tests below build on.
-const DEFAULT_THEME: Theme = { options: {}, fallback: true, args: [] };
-
-/**
- * Everything a chain needs from the command that invoked it.
- *
- * @param command the invoked subcommand, after parsing
- */
-export function chainOptionsFrom(command: Command): ChainOptions {
-  return { theme: themeFrom(command), shadcn: command.opts().shadcnCli };
-}
-
-/**
- * The `shadcn-init` chain: scaffold a stock shadcn app, theme it, and hand over to its
- * dev server.
- *
- * The forwarded args go to `shadcn init` -- the step whose options anyone would
- * want to reach (`--template next`, `-n my-app`, another `--preset`). The
- * `shadcn add` in the middle gets only our defaults; nothing about it is worth
- * configuring from out here.
- */
-export function initPlan(
-  source: string,
-  forwarded: string[] = [],
-  {
-    theme = DEFAULT_THEME,
-    shadcn = DEFAULT_SHADCN,
-  }: Partial<ChainOptions> = {},
-): Plan {
-  const args = mergeDefaults(INIT_DEFAULTS, forwarded);
-  const dir = lastName(args) ?? APP_NAME;
-
-  return {
-    source,
-    theme,
-    dir,
-    steps: [
-      {
-        kind: "spawn",
-        label: INIT_TARGET,
-        argv: [...NPX, shadcn, "init", ...args],
-        where: "cwd",
-      },
-      { kind: "cd", dir },
-      { kind: "item", file: ITEM },
-      // The same spec as the step above, deliberately: a chain pinned for the
-      // scaffold and floating for the install is worse than one that floats
-      // throughout, since the two would disagree about the registry format
-      // without saying so.
-      {
-        kind: "spawn",
-        label: ADD_TARGET,
-        argv: [
-          ...NPX,
-          shadcn,
-          "add",
-          `./${ITEM}`,
-          ...mergeDefaults(ADD_DEFAULTS, []),
-        ],
-        where: "project",
-      },
-      { kind: "rm", file: ITEM },
-      // The handover: long-running by design, stdio inherited, ctrl-C reaching
-      // it. Package-manager detection is out of scope -- `shadcn init` under
-      // `npx` writes a `package-lock.json` and the `dev` script npm will run.
-      {
-        kind: "spawn",
-        label: "npm run dev",
-        argv: ["npm", "run", "dev"],
-        where: "project",
-      },
-    ],
-  };
-}
-
-/**
- * The `shadcn-apply` chain: theme the project the command is run from, and stop there.
- *
- * No scaffold and no dev server -- this is someone's own project, already
- * running or not, and the only thing it wants is its CSS rewritten. It replaces
- * the three-command incantation the README used to document (generate to a file,
- * `shadcn add` it, remember to delete it), the last part of which is exactly the
- * kind of thing a CLI should be doing for you.
- *
- * The forwarded args go to `shadcn add` here, that being the only command in the
- * chain: `--overwrite`, `--dry-run`, `-c/--cwd`, `-p/--path` and `-s/--silent`
- * all reach it untouched.
- */
-export function applyPlan(
-  source: string,
-  forwarded: string[] = [],
-  {
-    theme = DEFAULT_THEME,
-    shadcn = DEFAULT_SHADCN,
-  }: Partial<ChainOptions> = {},
-): Plan {
-  return {
-    source,
-    theme,
-    steps: [
-      { kind: "item", file: ITEM },
-      {
-        kind: "spawn",
-        label: ADD_TARGET,
-        argv: [
-          ...NPX,
-          shadcn,
-          "add",
-          `./${ITEM}`,
-          ...mergeDefaults(ADD_DEFAULTS, forwarded),
-        ],
-        where: "cwd",
-      },
-      { kind: "rm", file: ITEM },
-    ],
-  };
-}
-
-// ─── Printing ────────────────────────────────────────────────────────────
-
-// Bare where a shell would leave the argument alone, single-quoted otherwise.
-// The source color is the reason this exists: an unquoted `#769CDF` is a comment
-// and takes the rest of the line with it.
-const SHELL_SAFE = /^[\w@%+=:,./-]+$/;
-
-function quote(argv: string[]) {
-  return argv
-    .map((arg) =>
-      SHELL_SAFE.test(arg) ? arg : `'${arg.replaceAll("'", `'\\''`)}'`,
-    )
-    .join(" ");
-}
-
-function renderStep(plan: Plan, step: Step) {
-  switch (step.kind) {
-    case "spawn":
-      return quote(step.argv);
-    case "cd":
-      return `cd ${step.dir}`;
-    // Rendered as the command someone could have run themselves -- theme options
-    // included, or the line would describe a different theme from the one the
-    // runner generates. The runner does the same thing in-process, being the very
-    // binary this spawns.
-    case "item":
-      return `${quote([...NPX, SELF, plan.source, ...plan.theme.args, "--format", "registry-item"])} > ${step.file}`;
-    case "rm":
-      return `rm ${step.file}`;
-  }
-}
-
-/**
- * The chain as a shell one-liner -- what `--print` writes.
- *
- * For docs, for debugging, and for anyone who would rather read what a command
- * is about to do than let it spawn `npx` on their machine. Rendered from the
- * same `Plan` the runner walks, so what it shows is what would run.
- */
-export function renderChain(plan: Plan) {
-  return plan.steps.map((step) => renderStep(plan, step)).join(" && ");
-}
-
-// ─── Running ─────────────────────────────────────────────────────────────
 
 function fail(message: string, code = 1): never {
   console.error(`Error: ${message}`);
   process.exit(code);
 }
 
-function run({ label, argv }: { label: string; argv: string[] }, cwd: string) {
-  const [command = "", ...args] = argv;
-  const { error, status, signal } = spawnSync(command, args, {
-    cwd,
-    stdio: "inherit",
-    shell: false,
-  });
-
-  if (error) fail(`${label} could not be started: ${error.message}`);
-  // Not a failure to report: a signal here is the user stopping the dev server
-  // they were handed. Exit as a shell would have, and say nothing.
-  if (signal) process.exit(128 + (os.constants.signals[signal] ?? 0));
-  if (status !== 0) fail(`${label} failed`, status ?? 1);
-}
-
-function writeItem({ source, theme }: Plan, file: string) {
-  // `shadcn-apply` runs in a directory full of someone else's files, and this one is
-  // both written and deleted. Refusing beats a silent round trip through their
-  // file.
+function writeItem(source: string, command: Command, file: string) {
+  // This runs in a directory full of someone else's files, and this one is both
+  // written and deleted. Refusing beats a silent round trip through their file.
   if (fs.existsSync(file))
     fail(
       `${path.basename(file)} already exists and would be overwritten, then deleted. Move it aside first.`,
     );
 
-  // Removed on the way out however we leave -- the `rm` step covers the happy
-  // path, this covers a failing `shadcn add`, and neither should leave a
-  // scratch file in a project that is not ours. Both are idempotent.
+  // Removed on the way out however we leave -- the happy path deletes it below,
+  // this covers a failing `shadcn add`, and neither should leave a scratch file
+  // in a project that is not ours. Both are idempotent.
   process.on("exit", () => fs.rmSync(file, { force: true }));
 
-  // `fallback` is honoured rather than forced: someone who always mounts an
-  // `<Mtb>` may well prefer a theme that failed to arrive to fail loudly --
-  // components rendering transparent -- over silently resolving to colors baked
-  // in weeks ago.
-  const item = builder(source, theme.options).toShadcnRegistryItem({
-    fallback: theme.fallback,
-  });
+  const { options, fallback } = themeFrom(command);
+  const item = builder(source, options).toShadcnRegistryItem({ fallback });
   fs.writeFileSync(file, `${JSON.stringify(item, null, 2)}\n`);
 }
 
-function runStep(plan: Plan, step: Step, projectDir: string) {
-  switch (step.kind) {
-    case "spawn":
-      return run(step, step.where === "project" ? projectDir : process.cwd());
-    case "item":
-      return writeItem(plan, path.join(projectDir, step.file));
-    case "rm":
-      return fs.rmSync(path.join(projectDir, step.file), { force: true });
-    // Nothing to do: the runner resolved the directory up front, where a shell
-    // would have changed into it. The step exists so that `--print` can say so.
-    case "cd":
-      return;
-  }
-}
-
-function runChain(plan: Plan) {
-  const projectDir = plan.dir ? path.resolve(plan.dir) : process.cwd();
-
-  // A plan with a `dir` is a plan that creates it, and `shadcn init` into an
-  // existing directory would write over whatever is in there.
-  if (plan.dir && fs.existsSync(projectDir))
-    fail(
-      `./${plan.dir} already exists. Pick another name with \`-- -n other-name\`, or remove it first.`,
-    );
-
-  for (const step of plan.steps) runStep(plan, step, projectDir);
-}
-
-function execute(plan: Plan, command: Command) {
-  if (command.opts().print === true) {
-    process.stdout.write(`${renderChain(plan)}\n`);
-    return;
-  }
-
-  runChain(plan);
-}
-
 /**
- * Run — or print — the `shadcn-init` chain.
- *
- * @param source source color in hex format
- * @param forwarded args given after the `--`, for `shadcn init`
- * @param command the invoked subcommand, read for its own options
- */
-export function runInit(source: string, forwarded: string[], command: Command) {
-  refuseOwnOptions(command, forwarded, INIT_TARGET);
-  execute(initPlan(source, forwarded, chainOptionsFrom(command)), command);
-}
-
-/**
- * Run — or print — the `shadcn-apply` chain.
+ * Run the `shadcn-apply` chain.
  *
  * @param source source color in hex format
  * @param forwarded args given after the `--`, for `shadcn add`
@@ -593,6 +94,19 @@ export function runApply(
   forwarded: string[],
   command: Command,
 ) {
-  refuseOwnOptions(command, forwarded, ADD_TARGET);
-  execute(applyPlan(source, forwarded, chainOptionsFrom(command)), command);
+  const file = path.resolve(ITEM);
+  writeItem(source, command, file);
+
+  // The argv verbatim, no interpolation into a shell: the source color and the
+  // forwarded args are both user input.
+  const [bin = "", ...args] = addArgv(command.opts().shadcnCli, forwarded);
+  const { error, status } = spawnSync(bin, args, {
+    stdio: "inherit",
+    shell: false,
+  });
+
+  if (error) fail(`shadcn add could not be started: ${error.message}`);
+  if (status !== 0) fail("shadcn add failed", status ?? 1);
+
+  fs.rmSync(file, { force: true });
 }

--- a/src/cli.shadcn.ts
+++ b/src/cli.shadcn.ts
@@ -17,7 +17,9 @@ import { builder } from "./lib/builder";
 // Spawned rather than assumed installed, so a bare `npx material-theme-builder
 // shadcn-apply` works with nothing on disk.
 const NPX = ["npx", "--yes"];
-const DEFAULT_SHADCN = "shadcn@latest";
+
+/** The shadcn `--shadcn-cli` runs when it is not told otherwise. */
+export const DEFAULT_SHADCN = "shadcn@latest";
 
 // `shadcn add` defaults its own `--yes` to *false*, and prompts for
 // confirmation on a `registry:theme` item ("You are about to install a new
@@ -32,22 +34,6 @@ const YES = "--yes";
 // taste. This runs inside someone's own project, hence a name unlikely to be
 // theirs, and a check before writing.
 const ITEM = "mtb.json";
-
-/**
- * Declare the options describing the run itself rather than the theme it
- * installs.
- *
- * `--shadcn-cli` rather than the obvious `--shadcn`, which is taken: the root
- * command has shipped a boolean `--shadcn` since 3.2.0 (it appends the alias
- * block to `--format tailwind`).
- */
-export function addChainOptions(command: Command) {
-  return command.option(
-    "--shadcn-cli <spec>",
-    "npx package spec for the shadcn CLI to run (a version, tag, fork or tarball — anything npx resolves)",
-    DEFAULT_SHADCN,
-  );
-}
 
 /**
  * The argv for the `shadcn add` that installs the generated item.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,14 +15,14 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { z } from "zod";
 import {
   addSourceArgument,
   addThemeOptions,
   builderOptions,
 } from "./cli.options";
-import { addChainOptions, runApply } from "./cli.shadcn";
+import { DEFAULT_SHADCN, runApply } from "./cli.shadcn";
 import {
   builder,
   DEFAULT_BLEND,
@@ -58,10 +58,27 @@ function writeFigmaTokens(theme: Theme, outputDir: string) {
   }
 }
 
+// The list `--format` accepts, and the list `writeOutput()` handles -- one array,
+// so a format cannot be offered without being written, or written without being
+// offered. Commander prints it in `--help` and refuses anything else, which is
+// what retires the `default:` branch that used to answer `--format bananas` with
+// JSON and not a word.
+const FORMATS = [
+  "json",
+  "css",
+  "figma",
+  "tailwind",
+  "shadcn",
+  "registry-item",
+  "flutter",
+] as const;
+
+type Format = (typeof FORMATS)[number];
+
 function writeOutput(
   theme: Theme,
   opts: {
-    format: string;
+    format: Format;
     output?: string;
     shadcn?: boolean;
     fallback?: boolean;
@@ -70,6 +87,8 @@ function writeOutput(
   const json = (value: unknown) => JSON.stringify(value, null, 2) + "\n";
 
   switch (opts.format) {
+    case "json":
+      return process.stdout.write(json(theme.toJson()));
     case "css":
       return process.stdout.write(theme.toCss());
     case "tailwind":
@@ -84,8 +103,6 @@ function writeOutput(
       return process.stdout.write(theme.toFlutter());
     case "figma":
       return writeFigmaTokens(theme, opts.output ?? "material-theme");
-    default:
-      return process.stdout.write(json(theme.toJson()));
   }
 }
 
@@ -113,10 +130,10 @@ addThemeOptions(
     "--custom-colors <json>",
     'Custom colors as JSON array (e.g. \'[{"name":"brand","hex":"#FF5733","blend":true}]\')',
   )
-  .option(
-    "--format <type>",
-    "Output format: json, css, figma, tailwind, shadcn, registry-item, or flutter",
-    "figma",
+  .addOption(
+    new Option("--format <type>", "Output format")
+      .choices(FORMATS)
+      .default("figma"),
   )
   .option("--output <dir>", "Output directory (required for figma format)")
   .option(
@@ -201,19 +218,25 @@ addThemeOptions(
 // it -- the published item is impersonal precisely because it cannot be asked
 // for a scheme.
 
-addChainOptions(
-  addThemeOptions(
-    addSourceArgument(
-      program
-        .command("shadcn-apply")
-        .description("Theme the shadcn project in the current directory"),
-    ).argument(
-      "[shadcn-args...]",
-      "Options after a `--`, forwarded verbatim to `shadcn add`",
-    ),
+addThemeOptions(
+  addSourceArgument(
+    program
+      .command("shadcn-apply")
+      .description("Theme the shadcn project in the current directory"),
+  ).argument(
+    "[shadcn-args...]",
+    "Options after a `--`, forwarded verbatim to `shadcn add`",
   ),
-).action((source: string, shadcnArgs: string[], _opts, command: Command) =>
-  runApply(source, shadcnArgs, command),
-);
+)
+  // `--shadcn-cli` rather than the obvious `--shadcn`, which is taken: the root
+  // command has shipped a boolean `--shadcn` since 3.2.0, just above.
+  .option(
+    "--shadcn-cli <spec>",
+    "npx package spec for the shadcn CLI to run (a version, tag, fork or tarball — anything npx resolves)",
+    DEFAULT_SHADCN,
+  )
+  .action((source: string, shadcnArgs: string[], _opts, command: Command) =>
+    runApply(source, shadcnArgs, command),
+  );
 
 program.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,8 +9,7 @@
 // $ node dist/cli.js '#6750A4' --format css
 // $ node dist/cli.js '#6750A4' --format shadcn
 // $ node dist/cli.js '#6750A4' --format registry-item
-// $ node dist/cli.js shadcn-init '#6750A4'
-// $ node dist/cli.js shadcn-apply '#6750A4' --print
+// $ node dist/cli.js shadcn-apply '#6750A4'
 // ```
 
 import * as fs from "node:fs";
@@ -23,7 +22,7 @@ import {
   addThemeOptions,
   builderOptions,
 } from "./cli.options";
-import { addChainOptions, runApply, runInit } from "./cli.shadcn";
+import { addChainOptions, runApply } from "./cli.shadcn";
 import {
   builder,
   DEFAULT_BLEND,
@@ -98,13 +97,13 @@ addThemeOptions(
       .name("material-theme-builder")
       .description("Generate a color theme from a source color"),
   )
-    // Required now that the theme options are declared on all three commands:
+    // Required now that the theme options are declared on the subcommand too:
     // without it, commander matches an option against the program first, so
-    // `init '#x' --scheme vibrant` would set the *program's* `--scheme` and hand
-    // `init` a default theme. Positional options recognize an option only where
-    // it was declared, which stops at the subcommand name. Nothing about the
-    // root command's own parsing changes -- the rule only applies to the operand
-    // that names a subcommand.
+    // `shadcn-apply '#x' --scheme vibrant` would set the *program's* `--scheme`
+    // and hand the subcommand a default theme. Positional options recognize an
+    // option only where it was declared, which stops at the subcommand name.
+    // Nothing about the root command's own parsing changes -- the rule only
+    // applies to the operand that names a subcommand.
     .enablePositionalOptions(),
 )
   // The root command's own: `--custom-colors` because only its formats can carry
@@ -183,7 +182,7 @@ addThemeOptions(
     writeOutput(result, opts);
   });
 
-// The subcommands live alongside the program's own action rather than turning it
+// The subcommand lives alongside the program's own action rather than turning it
 // into `.command(..., { isDefault: true })`: commander looks for a subcommand in
 // the first operand before reaching its own handler, so `<source>` keeps working
 // exactly as it did -- no hex color can collide with a subcommand name -- and
@@ -196,28 +195,11 @@ addThemeOptions(
 // us: it would also swallow a typo in one of our own flags and forward it
 // downstream, silently.
 //
-// Both carry the theme options too. They each generate a registry item, and a
-// command that could only ever generate the default theme would reproduce, inside
-// the two commands meant to remove the by-hand recipe, the very limitation that
-// motivated them -- the published item is impersonal precisely because it cannot
-// be asked for a scheme.
-
-addChainOptions(
-  addThemeOptions(
-    addSourceArgument(
-      program
-        .command("shadcn-init")
-        .description(
-          "Scaffold a new shadcn app themed from a source color, and start it",
-        ),
-    ).argument(
-      "[shadcn-args...]",
-      "Options after a `--`, forwarded verbatim to `shadcn init`",
-    ),
-  ),
-).action((source: string, shadcnArgs: string[], _opts, command: Command) =>
-  runInit(source, shadcnArgs, command),
-);
+// It carries the theme options too. It generates a registry item, and a command
+// that could only ever generate the default theme would reproduce, inside the
+// command meant to remove the by-hand recipe, the very limitation that motivated
+// it -- the published item is impersonal precisely because it cannot be asked
+// for a scheme.
 
 addChainOptions(
   addThemeOptions(


### PR DESCRIPTION
An épure pass over the two subcommands released yesterday in `3.3.0`. `shadcn-init` goes; `shadcn-apply` stays and stops second-guessing you.

**−856 lines net.** `cli.shadcn.ts` 598 → 112, its tests 550 → 211, `cli.options.ts` 197 → 156.

## `shadcn-init` is removed

It did three jobs and only the middle one was ours. Scaffolding is what `shadcn init` already does — better, with its own eighteen options — and starting a dev server is not a theming tool's business.

```sh
# before
$ npx material-theme-builder shadcn-init "#6750A4"

# now
$ npx shadcn@latest init --preset b0 --template vite
$ cd material-theme-app && npx material-theme-builder shadcn-apply "#6750A4"
```

Everything that existed to hold those three jobs together goes with it: the `--preset b0 --template vite` defaults, `mergeDefaults()`/`mentions()` (which injected them only where you had written none yourself), and `lastName()` — reading the project name back out of the merged argv, scanning from the end to mirror commander's last-one-wins, so the chain knew where to `cd`.

## `shadcn-apply` is a plain forwarder

Same mechanism, same output. What changed is the rule about the `--`, which is now true without an asterisk: **everything after the separator goes to `shadcn add` untouched.**

- **`--print` is gone**, and with it the `Plan`/`Step`/`renderChain`/`quote` model (~90 lines) that existed so the printed chain and the run chain could not disagree. On a single `shadcn add` there is nothing left to disagree about. It also took `specifiedThemeArgs()`, `THEME_OPTIONS` and `Theme.args` in `cli.options.ts`, which existed only to re-spell the given options into that printed line.
- **An option of ours after the `--` is no longer refused.** `refuseOwnOptions()`/`ownOptionIn()` gone. `shadcn-apply '#x' -- --scheme vibrant` now gets `error: unknown option '--scheme'` from shadcn. A worse message, and one rule instead of one rule plus an exception.
- **`--shadcn-cli` no longer validates its argument.** `parseShadcnSpec()` gone; whatever `npx` resolves, it runs.

## What stayed, and why

- **`--yes` on `shadcn add`** — and it owes nothing to `shadcn-init`. Checked against the installed shadcn 4.18.0: `add` defaults its own `--yes` to `false` (unlike `init`, where it is `true`) and prompts on exactly our item type:
  ```js
  if (!r.yes && !o && (m === "registry:style" || m === "registry:theme")) { /* confirm */ }
  ```
  Without it the command hangs in CI. Ours goes first, so a forwarded `--no-yes` still wins on commander's last-one-wins.
- **The `mtb.json` guard and the `process.on("exit")` cleanup** — this runs in a directory full of someone else's files, and that one is both written and deleted. Not intelligence about options; not leaving a scratch file behind.
- **The theme options** (`--scheme`, `--contrast`, the overrides, `--prefix`, `--no-fallback`) — the reason the command exists rather than the published impersonal item.
- **The name `shadcn-apply`** — `apply` is now a verb borrowed from a command we do not call, but renaming would make the same migration cost twice in one major. The 30-line comment defending it is gone.

## Verified against the real CLI

Not just unit tests — the built binary against shadcn 4.18.0 in this repo:

| invocation | result |
|---|---|
| `shadcn-apply '#6750A4' -- --dry-run` | `62 CSS variables added to src/styles/shadcn.css`, exit 0 |
| `-- --view src/styles/shadcn.css` | forwarded verbatim, shadcn renders the diff |
| `-- --scheme vibrant` | `unknown option '--scheme'` — forwarded, as intended |
| a pre-existing `mtb.json` | refused, file untouched |
| after a failing `shadcn add` | no `mtb.json` left behind |

`pnpm run lgtm` green: build, figma build, lint, format, exports, typecheck, 213 tests.

## Semver

Breaking on a surface published yesterday, so: changeset `major` → `4.0.0`. Someone typing `shadcn-init` gets commander's `unknown command` — no migration stub, that being exactly the complexity this PR removes. The `3.3.0` CHANGELOG entry stays as written; it is history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtANJj1cbBZpj12mEXjgSN
