### PR TITLE
chore: fix two `<details>` blocks, drop the Storybook watcher, add `dev`

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,18 +13,8 @@ import {
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
 /**
- * Keep `src/tailwind.css` and `src/shadcn.css` current while the dev server
- * runs.
- *
- * They are generated from their exporters by `pnpm run build`, which fires
- * once — so without this, editing the M3 vocabulary would leave the stories
- * showing the tokens as they were at boot, while everything around them hot
- * reloaded. Reading `builder` through `ssrLoadModule` is what makes it live:
- * it comes from `src/`, through Vite's module graph, so an edit invalidates it
- * the same way it invalidates a component.
- *
- * Dev only. `storybook build` has no server to load modules through, and needs
- * none: `pnpm run build-storybook` builds first.
+ * Generate the stylesheets the stories `@import`, so a fresh clone needs no
+ * prior build. Dev only -- `build-storybook` builds first.
  */
 function generateCss(): Plugin {
   return {
@@ -32,24 +22,14 @@ function generateCss(): Plugin {
     apply: "serve",
 
     async configureServer(server) {
-      const write = async () => {
-        const { builder } = await server.ssrLoadModule("/src/lib/builder.ts");
+      const { builder } = await server.ssrLoadModule("/src/lib/builder.ts");
 
-        for (const name of STYLESHEETS) {
-          const css = await outputFrom(name, builder);
-
-          if (writeIfChanged(join(root, "src", name), css)) {
-            server.config.logger.info(`[mtb] regenerated src/${name}`);
-          }
-        }
-      };
-
-      // Before the first request, so a fresh clone needs no prior build.
-      await write();
-
-      server.watcher.on("change", async (file) => {
-        if (file.startsWith(join(root, "src/lib"))) await write();
-      });
+      for (const name of STYLESHEETS) {
+        writeIfChanged(
+          join(root, "src", name),
+          await outputFrom(name, builder),
+        );
+      }
     },
   };
 }

--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ stylesheet for the standard tokens, and a plugin for the custom colors:
 Drop the `@plugin` line if you have no custom colors.
 
 <details>
-  Each name listed brings its four scheme roles and eleven shades — `bg-myCustomColor1`,
-`text-on-myCustomColor1`, `bg-myCustomColor1-container`,
+
+Each name listed brings its four scheme roles and eleven shades —
+`bg-myCustomColor1`, `text-on-myCustomColor1`, `bg-myCustomColor1-container`,
 `bg-myCustomColor1-300`.
 
 `prefix` mirrors `builder({ prefix })`:
@@ -417,11 +418,13 @@ some.
 </details>
 
 <details>
-  <summary>mapping details</summary>
-  see:
-  
-    - https://chatgpt.com/share/6899f20a-422c-8011-a072-62fb649589a0
-    - https://gemini.google.com/share/51e072b6f1d2
+<summary>mapping details</summary>
+
+see:
+
+- https://chatgpt.com/share/6899f20a-422c-8011-a072-62fb649589a0
+- https://gemini.google.com/share/51e072b6f1d2
+
 </details>
 
 # Dev

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
     "build-figma": "vite build --config figma-plugin/vite.config.ts && tsup --config figma-plugin/tsup.config.ts",
     "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN",
     "prepare": "pnpm run pretest && husky",
-    "changeset": "pnpm exec changeset"
+    "changeset": "pnpm exec changeset",
+    "dev": "pnpm run storybook"
   },
   "peerDependencies": {
     "react": "^19.2.3",

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -1,23 +1,8 @@
-// Generates the files the package ships that are derived from an exporter --
-// `tailwind.css` from `toTailwind()`, `shadcn.css` from `toShadcnAliases()`,
-// `registry-item.json` from `toShadcnRegistryItem()` -- into `src/` and
-// `dist/`.
+// Generates the exporter-derived files the package ships. Each has one
+// mapping behind it, so a hand-maintained copy could drift from it -- and did.
 //
-// The stylesheets used to be maintained by hand alongside the exporter they
-// mirror, which is how `--color-surface-tint` and `--color-surface-variant`
-// came to be missing from one and not the other. Generating them removes the
-// possibility: there is one mapping per file now, and the file is its output.
-//
-//   node scripts/generate.mjs
-//
-// Every copy is build output and all are gitignored: `dist/` is what ships,
-// `src/` is what Storybook `@import`s, so that its stylesheet can dogfood the
-// same arrangement the README recommends rather than a second-best one of its
-// own. That is why `pnpm run storybook` builds first. The registry item has no
-// `src/` copy -- nothing in the repo reads it, it is only ever fetched by
-// `shadcn add` from the published package.
-//
-// Runs from `tsup`'s `onSuccess`, so `pnpm run build` keeps them all current.
+// Run from `tsup`'s `onSuccess`. Every copy is gitignored build output: `dist/`
+// ships, `src/` is what Storybook `@import`s.
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -26,23 +11,12 @@ import prettier from "prettier";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-// The outputs name variables, never colors, so the source is arbitrary -- every
-// exporter here returns the same thing whatever it is asked about. Keep it that
-// way: an output that varied with the source would mean this file publishing one
-// theme, chosen here, to everyone who installs it. That is why the registry item
-// below is built without `{ fallback: true }` -- the variant that does bake
-// colors in belongs to the CLI, which is given a real source color.
+// Arbitrary, and has to stay able to be: these outputs name variables, never
+// colors. Hence no `{ fallback: true }` below -- baking colors in is for the
+// CLI, which is given a real source.
 const SOURCE = "#6750A4";
 
-/**
- * The generated files: which exporter fills each, under which header, in which
- * directories.
- *
- * The headers exist to explain to a reader of `dist/*.css` why editing is
- * futile, and to say what the file deliberately leaves out. JSON has no comment
- * syntax, so `registry-item.json` goes without one -- and needs it less, being
- * a file the `shadcn` CLI reads rather than a human.
- */
+/** Which exporter fills each file, under which banner, into which directories. */
 const FILES = {
   "tailwind.css": {
     parser: "css",
@@ -88,10 +62,7 @@ export const GENERATED_FILES = /** @type {(keyof FILES)[]} */ (
   Object.keys(FILES)
 );
 
-/**
- * The subset with a `src/` copy — the stylesheets Storybook `@import`s, and so
- * the only ones its dev-server plugin has to keep current.
- */
+/** The subset with a `src/` copy -- what Storybook `@import`s. */
 export const STYLESHEETS = GENERATED_FILES.filter((name) =>
   FILES[name].dirs.includes("src"),
 );
@@ -111,11 +82,8 @@ export async function formatOutput(name, body) {
 }
 
 /**
- * A file's contents, from whichever `builder` the caller can reach.
- *
- * Taking it as an argument is what lets Storybook regenerate on the fly: it
- * loads `builder` from source through Vite, where this module can only reach
- * the built bundle.
+ * A file's contents, from whichever `builder` the caller can reach -- this
+ * module can only reach `dist/`, Storybook loads `src/` through Vite.
  *
  * @param {keyof FILES} name which file, e.g. `tailwind.css`
  * @param {(source: string) => Record<string, () => never>} builder
@@ -125,11 +93,8 @@ export const outputFrom = (name, builder) =>
   formatOutput(name, FILES[name].from(builder));
 
 /**
- * Write `content` to `path`, unless that is what it already says.
- *
- * Only writing on a real change is what leaves the working tree alone when a
- * build has nothing to say -- and, in Storybook, what stops an unrelated edit
- * under `src/lib/` from invalidating the stylesheet and every utility with it.
+ * Write `content` to `path`, unless that is what it already says -- so a build
+ * with nothing to say leaves the working tree alone.
  *
  * @param {string} path
  * @param {string} content
@@ -148,10 +113,8 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  // Imported lazily, and through a URL rather than a literal specifier, so
-  // that only the writing half needs a build to have happened -- a literal
-  // would have Vite resolve `dist/` at transform time when the test imports
-  // this module.
+  // A URL rather than a literal specifier: a literal would have Vite resolve
+  // `dist/` at transform time when the test imports this module.
   const { builder } = await import(
     new URL("../dist/index.js", import.meta.url).href
   );


### PR DESCRIPTION
A line glued to `<details>` (or `<summary>`) stays inside the raw HTML block, so its markdown never gets parsed — that is why the backticks in the Tailwind section showed literally. Two blocks were affected; the `mapping details` one also had its links indented four spaces, which made them a code block.

The Storybook plugin now generates `src/tailwind.css` / `src/shadcn.css` once at boot instead of watching `src/lib/`. The M3 vocabulary changes rarely enough that a restart covers it, and the watcher was the only reason for half the surface in `scripts/generate.mjs`.

`pnpm dev` → storybook.

Comments trimmed across both files to what the code does not already say.

## Test plan

- [x] `pnpm run lgtm`
- [x] `src/*.css` deleted → regenerated ~4s into `storybook dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtANJj1cbBZpj12mEXjgSN