### PR TITLE
ci: stop auto-accepting Chromatic changes on main

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,6 +15,8 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run chromatic --exit-once-uploaded --auto-accept-changes main
+      # No `--auto-accept-changes main`: it accepted a broken shadcn baseline
+      # in #184 without anyone looking. Changes are accepted in the PR review.
+      - run: pnpm run chromatic --exit-once-uploaded
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
`--auto-accept-changes main` took whatever landed as the new baseline. That is how a broken shadcn mapping became the reference in #184 with no one looking — the PR build did show it (24 changes), but among 24 legitimate ones from the scaffold refresh, and the merge to `main` then locked it in.

Changes now get accepted in the PR review, where there is a diff to look at.

Note the trade-off: a push straight to `main` will leave the UI Tests check red until someone accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtANJj1cbBZpj12mEXjgSN