### PR TITLE
fix: read a blank core-color override as no override, and pick colors

### DIFF
--- a/.changeset/blank-core-override.md
+++ b/.changeset/blank-core-override.md
@@ -1,0 +1,10 @@
+---
+"material-theme-builder": patch
+---
+
+A blank core-color override now reads as no override, instead of throwing.
+
+`primary` and the other five are optional, but `builder(source, { primary: "" })`
+used to refuse `""` as an invalid hex — which is what a UI hands over for
+"cleared". Clearing a color picker now falls back to the palette generated from
+`source`. `source` itself is still required, so `""` there stays an error.

--- a/src/Mtb.stories.helpers.tsx
+++ b/src/Mtb.stories.helpers.tsx
@@ -1,11 +1,45 @@
+import type { Meta } from "@storybook/react-vite";
 import { cva, type VariantProps } from "class-variance-authority";
 import { kebabCase, startCase, upperFirst } from "lodash-es";
 import { createContext, useContext, type ComponentProps } from "react";
 import { ExportButton } from "./ExportButton";
-import { STANDARD_TONES, type TokenName } from "./lib/builder";
+import { schemeNames, STANDARD_TONES, type TokenName } from "./lib/builder";
 import { cn } from "./lib/utils";
 import type { Mtb } from "./Mtb";
 import { useMtb } from "./Mtb.context";
+
+/**
+ * `<Mtb>`'s props as controls, shared by every story that themes with them.
+ *
+ * Every color gets a picker. Left to infer, a `string` prop renders as a "Set
+ * string" button whose first click hands the builder `''` -- a color to pick is
+ * both the better control and the one that cannot produce a value the prop has
+ * no reading for.
+ */
+export const mtbArgTypes = {
+  source: { control: "color" },
+  scheme: { control: "select", options: schemeNames },
+  contrast: { control: { type: "range", min: -1, max: 1, step: 0.1 } },
+  primary: { control: "color" },
+  secondary: { control: "color" },
+  tertiary: { control: "color" },
+  error: { control: "color" },
+  neutral: { control: "color" },
+  neutralVariant: { control: "color" },
+  children: {
+    table: { disable: true }, // hide
+  },
+} satisfies Meta<typeof Mtb>["argTypes"];
+
+/**
+ * Same reason, for the one prop a picker cannot cover: an unset `object`
+ * control is a "Set object" button that clicks to `{}`, which is not a list of
+ * custom colors. Starting it at `[]` -- the builder's own default -- opens the
+ * array editor instead, and changes nothing about what is rendered.
+ */
+export const mtbArgs = {
+  customColors: [],
+} satisfies Partial<ComponentProps<typeof Mtb>>;
 
 function Foo({ children, ...props }: ComponentProps<"div">) {
   return (

--- a/src/Mtb.stories.tsx
+++ b/src/Mtb.stories.tsx
@@ -1,11 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ComponentProps, useMemo } from "react";
 import { allModes } from "../.storybook/modes";
-import { type MtbConfig, schemeNames } from "./lib/builder";
+import { type MtbConfig } from "./lib/builder";
 import { recolorizeSvg } from "./lib/recolorizeSvg";
 import { Mtb } from "./Mtb";
 import { useMtb } from "./Mtb.context";
-import { Layout, Scheme, Shades, TailwindScheme } from "./Mtb.stories.helpers";
+import {
+  Layout,
+  mtbArgs,
+  mtbArgTypes,
+  Scheme,
+  Shades,
+  TailwindScheme,
+} from "./Mtb.stories.helpers";
 
 import exampleSvg from "./assets/example.svg?raw";
 
@@ -41,39 +48,8 @@ const meta = {
   //     { name: "myCustomColor3", hex: "#E126C6", blend: false },
   //   ],
   // },
-  argTypes: {
-    source: {
-      control: "color",
-    },
-    scheme: {
-      control: "select",
-      options: schemeNames,
-    },
-    contrast: {
-      control: { type: "range", min: -1, max: 1, step: 0.1 },
-    },
-    primary: {
-      control: "color",
-    },
-    secondary: {
-      control: "color",
-    },
-    tertiary: {
-      control: "color",
-    },
-    error: {
-      control: "color",
-    },
-    neutral: {
-      control: "color",
-    },
-    neutralVariant: {
-      control: "color",
-    },
-    children: {
-      table: { disable: true }, // hide
-    },
-  },
+  args: mtbArgs,
+  argTypes: mtbArgTypes,
 } satisfies Meta<typeof Mtb>;
 
 export default meta;

--- a/src/Shadcn.stories.tsx
+++ b/src/Shadcn.stories.tsx
@@ -7,8 +7,8 @@ import { DataTable } from "./components/data-table";
 import { SectionCards } from "./components/section-cards";
 import { SiteHeader } from "./components/site-header";
 import { SidebarInset, SidebarProvider } from "./components/ui/sidebar";
-import { schemeNames } from "./lib/builder";
 import { Mtb } from "./Mtb";
+import { mtbArgs, mtbArgTypes } from "./Mtb.stories.helpers";
 
 // Where `shadcn add dashboard-01` put it. Left there rather than tidied into
 // `fixtures/`, so that re-running the command diffs to nothing.
@@ -50,14 +50,8 @@ const meta = {
       delay: 2000,
     },
   },
-  argTypes: {
-    source: { control: "color" },
-    scheme: { control: "select", options: schemeNames },
-    contrast: { control: { type: "range", min: -1, max: 1, step: 0.1 } },
-    children: {
-      table: { disable: true }, // hide
-    },
-  },
+  args: mtbArgs,
+  argTypes: mtbArgTypes,
 } satisfies Meta<typeof Mtb>;
 
 export default meta;

--- a/src/lib/builder.test.ts
+++ b/src/lib/builder.test.ts
@@ -81,6 +81,23 @@ describe("builder() › hex validation", () => {
     ).not.toThrow();
   });
 
+  // Storybook's controls, and any color picker, hand back `''` for "cleared"
+  // instead of dropping the key -- so an emptied override has to read as no
+  // override at all. Only `source` is required, and it keeps refusing `''`
+  // (above).
+  it.each([
+    ["primary"],
+    ["secondary"],
+    ["tertiary"],
+    ["error"],
+    ["neutral"],
+    ["neutralVariant"],
+  ])("should read a blank %s as no override", (option) => {
+    expect(builder(SOURCE, { [option]: "" }).toCss()).toEqual(
+      builder(SOURCE).toCss(),
+    );
+  });
+
   // It throws before any conversion, so a caller cannot get a half-built theme
   // out of a bad input by reaching for a different exporter.
   it("should refuse at the entry, not at an exporter", () => {

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -210,6 +210,19 @@ function assertHexInputs(
 }
 
 /**
+ * A core override as a UI hands it over, where "not set" arrives as `''`
+ * rather than as a missing key -- a cleared color picker, an empty text field.
+ *
+ * Every override is optional, so a blank one is the *absence* of an override:
+ * clearing the picker falls back to the palette generated from the source,
+ * which is the only reading that isn't a dead end. (`source` itself is
+ * required, so `''` there stays an error.)
+ */
+function optionalHex(hex: string | undefined) {
+  return hex?.trim() || undefined;
+}
+
+/**
  * The 28 standard tone values used in Material You tonal palettes.
  *
  * Tones are perceptual lightness in HCT, which is why the same tone reads as
@@ -504,21 +517,26 @@ export function builder(
     prefix = DEFAULT_PREFIX,
   }: Omit<MtbConfig, "source"> = {},
 ) {
-  assertHexInputs(
-    hexSource,
-    { primary, secondary, tertiary, error, neutral, neutralVariant },
-    hexCustomColors,
-  );
+  const cores = {
+    primary: optionalHex(primary),
+    secondary: optionalHex(secondary),
+    tertiary: optionalHex(tertiary),
+    error: optionalHex(error),
+    neutral: optionalHex(neutral),
+    neutralVariant: optionalHex(neutralVariant),
+  };
+
+  assertHexInputs(hexSource, cores, hexCustomColors);
 
   const sourceArgb = argbFromHex(hexSource);
   const sourceHct = Hct.fromInt(sourceArgb);
 
   // Determine the effective source for harmonization
   // When primary is defined, it becomes the effective source
-  const effectiveSource = primary || hexSource;
+  const effectiveSource = cores.primary || hexSource;
   const effectiveSourceArgb = argbFromHex(effectiveSource);
-  const effectiveSourceForHarmonization = primary
-    ? argbFromHex(primary)
+  const effectiveSourceForHarmonization = cores.primary
+    ? argbFromHex(cores.primary)
     : sourceArgb;
 
   // Create a base scheme to get the standard chroma values
@@ -531,32 +549,32 @@ export function builder(
     // Core colors (hex may be undefined)
     {
       name: "primary",
-      hex: primary,
+      hex: cores.primary,
       core: true,
       chromaSource: "primary",
     },
     {
       name: "secondary",
-      hex: secondary,
+      hex: cores.secondary,
       core: true,
       chromaSource: "primary",
     },
     {
       name: "tertiary",
-      hex: tertiary,
+      hex: cores.tertiary,
       core: true,
       chromaSource: "primary",
     },
-    { name: "error", hex: error, core: true, chromaSource: "primary" },
+    { name: "error", hex: cores.error, core: true, chromaSource: "primary" },
     {
       name: "neutral",
-      hex: neutral,
+      hex: cores.neutral,
       core: true,
       chromaSource: "neutral",
     },
     {
       name: "neutralVariant",
-      hex: neutralVariant,
+      hex: cores.neutralVariant,
       core: true,
       chromaSource: "neutralVariant",
     },


### PR DESCRIPTION
Clicking `primary`'s **Set string** in the Shadcn story threw `Invalid primary: ''` and blanked the story.

Storybook infers that button for every `string` prop left out of `argTypes`, and its first click hands the builder `''`. The Shadcn story declared only `source`, so all six core overrides were that button.

Both halves are fixed, because either one alone still breaks: a picker can be cleared, and a story can forget to declare a control.

- `optionalHex()` reads a blank override as its *absence*, falling back to the palette generated from `source`. `source` itself is required, so `''` there stays an error.
- `mtbArgTypes` gives every color a picker, shared by the Mtb and Shadcn stories rather than restated in each. `mtbArgs` starts `customColors` at `[]` for the same reason one rung down: an unset object control clicks to `{}`, which is not a list of custom colors. Story args still win over both.

Checked in the running Storybook on `shadcn--dashboard-01`: `#ff0000` on `primary` repaints the dashboard, and emptying the field returns to the source palette with no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuZ72Afau6Cv9hsfPaZdqP
