### PR TITLE
feat(storybook): dock the generated scheme over any story

### DIFF
--- a/.changeset/scheme-overlay.md
+++ b/.changeset/scheme-overlay.md
@@ -1,0 +1,19 @@
+---
+"material-theme-builder": minor
+---
+
+`ExportButton` no longer places itself, and wears the Figma mark.
+
+It used to be `fixed` in the bottom-right corner on its own account, which is a
+decision that belongs to whoever renders it — Storybook now stacks it with a
+second FAB, and two self-placing FABs land on each other. Wrap it in your own
+positioned element to keep it where it was:
+
+```jsx
+<div className="fixed right-6 bottom-6">
+  <ExportButton config={config} />
+</div>
+```
+
+Its download arrow is now the Figma mark, which is what the file it hands over
+actually is.

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,0 +1,46 @@
+import { PaintBrushAltIcon } from "@storybook/icons";
+import { createElement } from "react";
+import { IconButton } from "storybook/internal/components";
+import { addons, types, useGlobals } from "storybook/manager-api";
+
+const ADDON_ID = "mtb/scheme-overlay";
+
+/**
+ * The scheme overlay's on/off switch.
+ *
+ * `createElement` rather than JSX: Storybook builds the manager with the
+ * classic runtime, so JSX here compiles to `React.createElement` -- and the
+ * `import React` that needs is precisely what `organize-imports` strips out
+ * again, TypeScript having been told `react-jsx`. Two calls are cheaper than
+ * arguing with that.
+ */
+function SchemeOverlayTool() {
+  const [globals, updateGlobals] = useGlobals();
+  const shown = globals.schemeOverlay === "shown";
+
+  return createElement(
+    IconButton,
+    {
+      active: shown,
+      title: "Dock the generated scheme over the story",
+      onClick: () =>
+        updateGlobals({ schemeOverlay: shown ? "hidden" : "shown" }),
+    },
+    createElement(PaintBrushAltIcon),
+  );
+}
+
+/**
+ * A `globalTypes` toolbar would have been less code, but it can only render a
+ * dropdown — two items deep, for what is one bit. Registering the tool by hand
+ * keeps the bit a bit: one icon, pressed or not.
+ */
+addons.register(ADDON_ID, () => {
+  addons.add(ADDON_ID, {
+    type: types.TOOL,
+    title: "Scheme",
+    // Nothing to overlay in docs, where every story renders at once.
+    match: ({ viewMode }) => viewMode === "story",
+    render: () => createElement(SchemeOverlayTool),
+  });
+});

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,6 +7,8 @@ seedrandom("deterministic-random-for-storybook", { global: true }); // determini
 
 import { withThemeByClassName } from "@storybook/addon-themes";
 import { TooltipProvider } from "../src/components/ui/tooltip";
+import type { MtbConfig } from "../src/lib/builder";
+import { Fabs, SchemeOverlay } from "../src/Mtb.stories.helpers";
 
 const preview: Preview = {
   parameters: {
@@ -17,11 +19,34 @@ const preview: Preview = {
       },
     },
   },
+  /**
+   * Off by default -- and a global rather than an arg, because the poster is a
+   * way of *looking* at any story, like the theme switcher next to it, not a
+   * prop of the one being looked at. Its toolbar button is in `manager.ts`.
+   *
+   * It switches the poster and nothing else: the FABs below are always there,
+   * the way they were when `Layout` drew the export one.
+   */
+  initialGlobals: {
+    schemeOverlay: "hidden",
+  },
   decorators: [
     (Story) => (
       <TooltipProvider>
         <Story />
       </TooltipProvider>
+    ),
+    (Story, { args, globals }) => (
+      <>
+        <Story />
+        {globals.schemeOverlay === "shown" && (
+          <SchemeOverlay
+            theme={globals.theme === "dark" ? "dark" : "light"}
+            customColors={args.customColors}
+          />
+        )}
+        <Fabs config={args as MtbConfig} />
+      </>
     ),
     withThemeByClassName({
       themes: {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@fontsource-variable/inter": "^5.3.0",
     "@storybook/addon-docs": "^10.1.11",
     "@storybook/addon-themes": "^10.1.11",
+    "@storybook/icons": "^2.1.0",
     "@storybook/react-vite": "^10.1.11",
     "@tailwindcss/postcss": "^4.1.18",
     "@tanstack/react-table": "^9.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 2.29.8(@types/node@24.13.3)
       '@chromatic-com/storybook':
         specifier: ^5.0.0
-        version: 5.0.1(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 5.0.1(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -56,13 +56,16 @@ importers:
         version: 5.3.0
       '@storybook/addon-docs':
         specifier: ^10.1.11
-        version: 10.2.12(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.12(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/addon-themes':
         specifier: ^10.1.11
-        version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))
+      '@storybook/icons':
+        specifier: ^2.1.0
+        version: 2.1.0(react@19.2.4)
       '@storybook/react-vite':
         specifier: ^10.1.11
-        version: 10.2.12(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.12(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.2.1
@@ -182,7 +185,7 @@ importers:
         version: 2.0.8(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook:
         specifier: ^10.1.11
-        version: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
@@ -1501,11 +1504,10 @@ packages:
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
-  '@storybook/icons@2.0.1':
-    resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
+  '@storybook/icons@2.1.0':
+    resolution: {integrity: sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@storybook/react-dom-shim@10.2.12':
     resolution: {integrity: sha512-T4uHPAgtEbroRazubGDIByopvNw1WKAp1kOlNqKWR8LZPDaVyEr8X7J6zaJo1y+vE8j6fUXvk6jZVMwhi/Jeig==}
@@ -5160,13 +5162,13 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@chromatic-com/storybook@5.0.1(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@chromatic-com/storybook@5.0.1(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 13.3.5
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
       strip-ansi: 7.1.2
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -5830,15 +5832,15 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@10.2.12(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/addon-docs@10.2.12(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/icons': 2.1.0(react@19.2.4)
+      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -5847,15 +5849,15 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-themes@10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-themes@10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))':
     dependencies:
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/builder-vite@10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -5863,9 +5865,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/csf-plugin@10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
@@ -5874,30 +5876,29 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@storybook/icons@2.1.0(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+
+  '@storybook/react-dom-shim@10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
 
-  '@storybook/react-dom-shim@10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
-    dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-
-  '@storybook/react-vite@10.2.12(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/react-vite@10.2.12(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@storybook/react': 10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.2.12(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/react': 10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.4
       react-docgen: 8.0.2
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -5907,14 +5908,14 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/react@10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4))
       react: 19.2.4
       react-docgen: 8.0.2
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8574,10 +8575,10 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.8.1)(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/icons': 2.1.0(react@19.2.4)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
@@ -8594,7 +8595,6 @@ snapshots:
       - '@testing-library/dom'
       - bufferutil
       - react
-      - react-dom
       - utf-8-validate
 
   strict-event-emitter@0.5.1:

--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -48,22 +48,18 @@ export function ExportButton({ config }: ExportButtonProps) {
       onClick={handleExport}
       title="Export Figma Tokens"
       aria-label="Export Figma Tokens"
-      className="fixed z-50 bottom-6 right-6"
     >
+      {/* The Figma mark: what comes down is a Figma tokens file, not a
+          generic download, and this is the one place a logo says which. */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"
         height="24"
         viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
+        fill="currentColor"
+        aria-hidden
       >
-        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-        <polyline points="7 10 12 15 17 10" />
-        <line x1="12" y1="15" x2="12" y2="3" />
+        <path d="M8 24a4 4 0 0 1-4-4 4 4 0 0 1 4-4h4v4a4 4 0 0 1-4 4Zm0-6.5A2.5 2.5 0 0 0 5.5 20 2.5 2.5 0 0 0 8 22.5 2.5 2.5 0 0 0 10.5 20v-2.5H8ZM8 16a4 4 0 0 1-4-4 4 4 0 0 1 4-4h4v8H8Zm0-6.5A2.5 2.5 0 0 0 5.5 12 2.5 2.5 0 0 0 8 14.5h2.5v-5H8ZM8 8a4 4 0 0 1-4-4 4 4 0 0 1 4-4h4v8H8Zm0-6.5A2.5 2.5 0 0 0 5.5 4 2.5 2.5 0 0 0 8 6.5h2.5v-5H8Zm8 6.5h-4V0h4a4 4 0 0 1 4 4 4 4 0 0 1-4 4Zm-2.5-1.5H16A2.5 2.5 0 0 0 18.5 4 2.5 2.5 0 0 0 16 1.5h-2.5v5ZM16 16a4 4 0 0 1-4-4 4 4 0 0 1 4-4 4 4 0 0 1 4 4 4 4 0 0 1-4 4Zm0-6.5a2.5 2.5 0 0 0-2.5 2.5 2.5 2.5 0 0 0 2.5 2.5 2.5 2.5 0 0 0 2.5-2.5A2.5 2.5 0 0 0 16 9.5Z" />
       </svg>
     </Fab>
   );

--- a/src/Mtb.stories.helpers.tsx
+++ b/src/Mtb.stories.helpers.tsx
@@ -1,12 +1,25 @@
 import type { Meta } from "@storybook/react-vite";
 import { cva, type VariantProps } from "class-variance-authority";
 import { kebabCase, startCase, upperFirst } from "lodash-es";
-import { createContext, useContext, type ComponentProps } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  type ComponentProps,
+} from "react";
+import { Fab } from "./components/m3/Fab";
 import { ExportButton } from "./ExportButton";
-import { schemeNames, STANDARD_TONES, type TokenName } from "./lib/builder";
+import {
+  DEFAULT_CONTRAST,
+  DEFAULT_PREFIX,
+  DEFAULT_SCHEME,
+  schemeNames,
+  STANDARD_TONES,
+  type MtbConfig,
+  type TokenName,
+} from "./lib/builder";
 import { cn } from "./lib/utils";
 import type { Mtb } from "./Mtb";
-import { useMtb } from "./Mtb.context";
 
 /**
  * `<Mtb>`'s props as controls, shared by every story that themes with them.
@@ -171,57 +184,65 @@ function Swatch({
 }
 
 /**
+ * The gaps, label size and cell heights `Scheme` and `Shades` paint with,
+ * `@scope`d to the element this sits in.
+ *
+ * Its own component because two places need it: `Layout`, and `SchemeOverlay`
+ * -- which docks a poster outside any `<Mtb>`, so it cannot go through
+ * `Layout`.
+ */
+function PosterStyle({ notext }: { notext?: boolean }) {
+  return (
+    <style>{`
+      @scope {
+        & {
+          --gap1:0.5rem;
+          --gap2:1px;
+
+          --fs:${notext ? 0 : ".8rem"};
+          @media (max-width: 768px) {--fs:0;}
+
+          @media (max-width: 768px) {
+            --gap1:2px;
+          }
+
+
+          p {
+            font-family:sans-serif;
+            color:white;mix-blend-mode:difference;
+            white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+
+            font-size:var(--fs);
+            margin:.35rem;
+
+          }
+
+          [class*="h-20"],[class*="h-16"] {
+            @media (max-width: 768px) {
+              height:45px;
+            }
+          }
+        }
+      }
+    `}</style>
+  );
+}
+
+/**
  * Storybook layout wrapper with optional source-color label and export button.
  */
 export function Layout({
   notext,
-  noExport,
   children,
 }: {
   /** Hide the source-color text label. */
   notext?: boolean;
-  /** Hide the export button. */
-  noExport?: boolean;
   /** Story content to render inside the layout. */
   children: React.ReactNode;
 }) {
-  const { initials } = useMtb();
-
   return (
     <div className="flex flex-col gap-6 max-w-208 mx-auto">
-      <style>{`
-        @scope {
-          & {
-            --gap1:0.5rem;
-            --gap2:1px;
-            
-            --fs:${notext ? 0 : ".8rem"};
-            @media (max-width: 768px) {--fs:0;}
-
-            @media (max-width: 768px) {
-              --gap1:2px;
-            }
-
-
-            p {
-              font-family:sans-serif;
-              color:white;mix-blend-mode:difference;
-              white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
-
-              font-size:var(--fs);
-              margin:.35rem;
-
-            }
-
-            [class*="h-20"],[class*="h-16"] {
-              @media (max-width: 768px) {
-                height:45px;
-              }
-            }
-          }
-        }
-      `}</style>
-      {!noExport && <ExportButton config={initials} />}
+      <PosterStyle notext={notext} />
       {children}
     </div>
   );
@@ -1133,5 +1154,152 @@ export function TailwindScheme() {
         </p>
       </div>
     </>
+  );
+}
+
+/**
+ * The poster, docked in a corner of the canvas — the generated scheme, right
+ * next to whatever the story paints with it.
+ *
+ * Reads nothing from `<Mtb>`: the swatches paint from `--md-sys-color-*`, and
+ * the story's own provider declares those on `:root`/`.dark` for the whole
+ * document. That is what lets a global decorator render this from *outside*
+ * the provider, over any story.
+ *
+ * `theme` has to be told, and has to match the class on `<html>`: those two
+ * blocks are the only place the light and dark values differ, so a light
+ * poster inside a dark page would read the dark ones and lie.
+ */
+export function SchemeOverlay({
+  theme,
+  customColors,
+}: {
+  /** Which of the two scheme blocks to read — the page's own theme. */
+  theme: "light" | "dark";
+  /** Custom colors, as the story's `<Mtb>` got them. */
+  customColors?: ComponentProps<typeof Mtb>["customColors"];
+}) {
+  return (
+    <div className="fixed bottom-2 left-2 z-50 overflow-hidden rounded shadow-2xl ring-1 ring-neutral-500/50">
+      {/* Scaled as a whole rather than re-sized cell by cell, so the poster
+          stays the poster. `zoom` and not `transform`, which would leave the
+          wrapper reserving all 40rem of it. */}
+      <div className="w-160" style={{ zoom: 0.35 }}>
+        <PosterStyle notext />
+        <Scheme theme={theme} customColors={customColors}>
+          <Shades customColors={customColors} noTitle />
+        </Scheme>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * `name value`, unless the value is blank or already what the CLI defaults to.
+ *
+ * An empty string counts as blank on purpose: that is what a cleared color
+ * picker hands over, and `builder()` reads it as no override rather than as a
+ * color.
+ */
+function cliFlag(name: string, value?: string | number, fallback?: unknown) {
+  if (value === undefined || value === "" || value === fallback) return [];
+
+  return [
+    typeof value === "string" ? `${name} "${value}"` : `${name} ${value}`,
+  ];
+}
+
+/**
+ * The `shadcn-apply` invocation for a theme — the same theme, spelled as the
+ * CLI takes it.
+ *
+ * Only what differs from the defaults is written out, so the command reads as
+ * the *changes* made in the controls rather than as a dump of every option. Two
+ * of the props have no flag at all: `customColors`, which a registry item
+ * cannot carry, and `colorMatch`, which is not a CLI option.
+ *
+ * @see https://github.com/abernier/material-theme-builder#shadcn-apply
+ */
+function shadcnApplyCommand(config: MtbConfig) {
+  return [
+    `npx material-theme-builder@latest shadcn-apply "${config.source}"`,
+    ...cliFlag("--scheme", config.scheme, DEFAULT_SCHEME),
+    ...cliFlag("--contrast", config.contrast, DEFAULT_CONTRAST),
+    ...cliFlag("--primary", config.primary),
+    ...cliFlag("--secondary", config.secondary),
+    ...cliFlag("--tertiary", config.tertiary),
+    ...cliFlag("--error", config.error),
+    ...cliFlag("--neutral", config.neutral),
+    ...cliFlag("--neutral-variant", config.neutralVariant),
+    ...cliFlag("--prefix", config.prefix, DEFAULT_PREFIX),
+  ].join(" ");
+}
+
+/**
+ * FAB that copies the CLI command for the theme currently in the controls.
+ *
+ * The point of the stories is to find a theme by moving the controls around;
+ * this is what carries the one you settled on out of Storybook and into a
+ * project, without transcribing eight hex values by hand.
+ *
+ */
+function ShadcnApplyFab({ config }: { config: MtbConfig }) {
+  const [copied, setCopied] = useState(false);
+  const command = shadcnApplyCommand(config);
+
+  return (
+    <Fab
+      color="tertiary-container"
+      title={command}
+      aria-label={`Copy: ${command}`}
+      onClick={async () => {
+        await navigator.clipboard.writeText(command);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+    >
+      {/* The shadcn mark, next to the Figma one on the FAB below: the pair
+          reads as the two places a theme can go, which a shell prompt did
+          not. The tick takes its place while the command sits on the
+          clipboard -- the only feedback a copy button gets. */}
+      {copied ? (
+        <span aria-hidden className="font-mono text-2xl leading-none">
+          ✓
+        </span>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 256 256"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="32"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <line x1="208" y1="128" x2="128" y2="208" />
+          <line x1="192" y1="40" x2="40" y2="192" />
+        </svg>
+      )}
+    </Fab>
+  );
+}
+
+/**
+ * The story's floating actions, bottom-right: take this theme away as a CLI
+ * command, or as Figma tokens.
+ *
+ * One fixed container holding both, rather than two FABs each placing itself:
+ * placed separately, the second one lands on the first, and only on the stories
+ * that happen to draw both.
+ */
+export function Fabs({ config }: { config: MtbConfig }) {
+  return (
+    <div className="fixed right-6 bottom-6 z-50 flex flex-col gap-1">
+      <ShadcnApplyFab config={config} />
+      <ExportButton config={config} />
+    </div>
   );
 }


### PR DESCRIPTION
The poster only existed as the Mtb stories themselves, so the one story that needs it most — shadcn's `dashboard-01`, where the theme is *worn* rather than displayed — had no way to show what it was wearing while the controls moved.

## What lands

**A toolbar toggle** (`manager.ts`) docks the poster bottom-left over any story.

It reads nothing from `<Mtb>`: the swatches paint from `--md-sys-color-*`, which the story's own provider declares on `:root`/`.dark` document-wide — that is what lets a global decorator render it from *outside* the provider. `theme` has to be told, and has to match the class on `<html>`: those two blocks are the only place light and dark differ, so a light poster in a dark page would read the dark values and lie.

The toggle is a `types.TOOL` rather than a `globalTypes` toolbar, which can only render a dropdown — two items deep, for what is one bit.

**Two FABs, bottom-right, in one fixed flex column** — the two ways a theme leaves Storybook:

- the `shadcn-apply` command for the theme currently in the controls, copied to the clipboard. Only what differs from the CLI defaults is written out, so it reads as the *changes* made rather than a dump of every option;
- the Figma tokens export.

One container rather than two self-placing FABs: placed separately, the second lands on the first, and only on the stories that draw both.

## Public change

`ExportButton` is exported from `material-theme-builder/react`, and gives up its own `fixed bottom-6 right-6` for that stack — positioning belongs to whoever renders it. Its download arrow becomes the Figma mark. Minor changeset included, with the wrapper to restore the old placement.

## Notes

- Chromatic will move: the FABs render on every story now (Mtb stories go from one to two, Shadcn/Flowfield gain both). The poster itself is off by default, so it snapshots nothing.
- `manager.ts` uses `createElement` rather than JSX — Storybook builds the manager with the classic runtime, and the `import React` that needs is precisely what `prettier-plugin-organize-imports` strips back out.
- `PosterStyle` extracts `Layout`'s `@scope`d `<style>` so the overlay can share it without going through `Layout` (which needs a `<Mtb>` above it, and the decorator has none).

`lgtm` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKQKa1TuuUj3qb3z6PnzXv
