### PR TITLE
feat: mapping as a first-class concept, shadcn as its first citizen

### DIFF
--- a/.changeset/mapping-parameter.md
+++ b/.changeset/mapping-parameter.md
@@ -1,0 +1,20 @@
+---
+"material-theme-builder": minor
+---
+
+feat: mapping as a first-class concept, shadcn as its first citizen
+
+`toMapping()` and `toMappingAliases()` project the M3 scheme onto any CSS
+variable vocabulary — concrete `oklch()` values, or a `var()` block that follows
+whichever `<Mtb>` is above it. Every sys-color token is mappable, custom colors
+included.
+
+shadcn is now one preset over that: `toShadcn()`, `toShadcnAliases()`,
+`toShadcnRegistryItem()` and `toTailwind({ shadcn })` all take a `mapping`,
+merged over the defaults, so naming `--primary` redirects that one variable and
+leaves the rest alone. A name shadcn does not have is added rather than refused.
+The CLI reads the same thing off disk with `--mapping <file.json>`, on both
+`material-theme-builder` and `shadcn-apply`.
+
+A mapping that names a token the scheme does not carry now throws, where the
+alias renderings used to emit a `var()` nothing declares.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ theme.toFlutter();
 theme.toShadcn();
 theme.toShadcnAliases();
 theme.toShadcnRegistryItem({ fallback: true });
+
+// Any other design system whose colors are CSS variables
+theme.toMapping({ "--bs-body-bg": "surface", "--bs-primary": "primary" });
+theme.toMappingAliases({ "--bs-primary": "primary" });
+```
+
+Every M3 token is mappable — including this theme's custom colors. `toMapping()`
+freezes the colors in, `toMappingAliases()` emits a `var()` block that follows
+whichever `<Mtb>` is above it:
+
+```css
+:root {
+  --bs-primary: var(--md-sys-color-primary);
+}
 ```
 
 ## CLI
@@ -349,6 +363,43 @@ rather than on order — which is what lets the `@import` sit with your others.
   --sidebar-ring: var(--md-sys-color-primary);
 }
 ```
+
+</details>
+
+<details>
+<summary>Changing what maps to what</summary>
+
+Pass `mapping` to any of the three exporters. It is merged over the defaults, so
+name only what changes:
+
+```ts
+const theme = builder("#6750A4", {
+  customColors: [{ name: "brand", hex: "#FF5733" }],
+});
+
+theme.toShadcnAliases({
+  mapping: {
+    "--primary": "tertiary", // redirect one
+    "--brand": "brand", // or add one shadcn does not have
+  },
+});
+```
+
+Values are M3 sys-color tokens, kebab-case; an unknown one throws rather than
+emitting a `var()` nothing declares. The same option reaches
+`toShadcn()`, `toShadcnRegistryItem()` and `toTailwind({ shadcn: { mapping } })`,
+so the halves cannot drift.
+
+From the CLI, the same thing as a JSON file:
+
+```sh
+$ echo '{"--primary": "tertiary"}' > mapping.json
+$ npx material-theme-builder "#6750A4" --format registry-item --mapping mapping.json
+$ npx material-theme-builder shadcn-apply "#6750A4" --mapping mapping.json
+```
+
+For a vocabulary that is not shadcn's at all, see
+[`toMapping()`](#programmatic-api).
 
 </details>
 

--- a/src/cli.options.ts
+++ b/src/cli.options.ts
@@ -12,12 +12,15 @@
 // `--format json|css|figma|tailwind` really do emit them. An option that provably
 // does nothing would be worse than a missing one.
 
+import * as fs from "node:fs";
+
 import {
   InvalidArgumentError,
   Option,
   type Command,
   type OptionValues,
 } from "commander";
+import { z } from "zod";
 
 import {
   DEFAULT_CONTRAST,
@@ -25,8 +28,56 @@ import {
   DEFAULT_SCHEME,
   isHexColor,
   schemeNames,
+  type Mapping,
   type MtbConfig,
 } from "./lib/builder";
+
+// A flat object of strings, and no more: the M3 token each name is checked
+// against is the theme's business -- `builder()` knows which tokens exist,
+// including this theme's custom colors, and says so by name. Here it is only the
+// *shape* that has to be right, so that a JSON array or a nested object is
+// refused as such rather than reaching the builder as an unreadable mapping.
+const mappingSchema = z.record(
+  z.string(),
+  z.string(),
+) satisfies z.ZodType<Mapping>;
+
+/**
+ * Commander parser for `--mapping` — a path to a JSON file.
+ *
+ * A file rather than an inline `<json>` like `--custom-colors`: a mapping is
+ * thirty-odd lines someone keeps and edits, not something typed at a prompt.
+ *
+ * Read and checked here, at parse time, so a missing file or a stray array is
+ * one line with the path in it -- the same reason `parseHexColor()` restates
+ * what `builder()` already enforces.
+ */
+export function parseMappingFile(file: string): Mapping {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(file, "utf8");
+  } catch {
+    throw new InvalidArgumentError(`could not read '${file}'.`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    throw new InvalidArgumentError(`'${file}' is not valid JSON.`);
+  }
+
+  const result = mappingSchema.safeParse(parsed);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const where = issue?.path.length ? ` at ${issue.path.join(".")}` : "";
+    throw new InvalidArgumentError(
+      `'${file}'${where}: ${issue?.message ?? "is invalid"}. Expected an object of CSS variable to M3 token, e.g. {"--primary": "tertiary"}.`,
+    );
+  }
+
+  return result.data;
+}
 
 /**
  * Commander parser for a hex color — the `<source>` argument, and every
@@ -74,6 +125,8 @@ export type Theme = {
   options: ThemeOptions;
   /** Whether the item bakes this theme's colors in as the `var()` fallbacks. */
   fallback: boolean;
+  /** Variables to map differently, merged over the shadcn preset. */
+  mapping?: Mapping;
 };
 
 /**
@@ -104,6 +157,11 @@ export function addThemeOptions(command: Command) {
       "--neutral-variant <hex>",
       "Neutral variant color override",
       parseHexColor,
+    )
+    .option(
+      "--mapping <file>",
+      'JSON file of shadcn variable to M3 token, merged over the defaults (e.g. {"--primary": "tertiary"})',
+      parseMappingFile,
     )
     .option(
       "--no-fallback",
@@ -152,5 +210,6 @@ export function themeFrom(command: Command): Theme {
     // which is what makes baking its colors in as the fallbacks free. See
     // `buildShadcnRegistryItem()`.
     fallback: opts.fallback ?? true,
+    mapping: opts.mapping,
   };
 }

--- a/src/cli.shadcn.test.ts
+++ b/src/cli.shadcn.test.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -9,6 +10,20 @@ import { addThemeOptions, themeFrom } from "./cli.options";
 import { addArgv } from "./cli.shadcn";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Written rather than committed: `--mapping` takes a path, so what is exercised
+// is reading one, and three one-line files say more inline than in a fixtures
+// directory nobody opens.
+const fixtures = fs.mkdtempSync(path.join(os.tmpdir(), "mtb-mapping-"));
+const fixture = (name: string, contents: string) => {
+  const file = path.join(fixtures, name);
+  fs.writeFileSync(file, contents);
+  return file;
+};
+
+const mappingFile = fixture("mapping.json", '{"--primary": "tertiary"}');
+fixture("not-json.txt", "not json");
+fixture("mapping-array.json", '["--primary"]');
 
 /** The args `shadcn add` is really spawned with, past its own name. */
 const added = (forwarded: string[] = []) => {
@@ -79,6 +94,13 @@ describe("theme options", () => {
     expect(themeFrom(command([])).fallback).toBe(true);
     expect(themeFrom(command(["--no-fallback"])).fallback).toBe(false);
   });
+
+  it("should read --mapping off disk, as an object", () => {
+    expect(themeFrom(command([])).mapping).toBeUndefined();
+    expect(themeFrom(command(["--mapping", mappingFile])).mapping).toEqual({
+      "--primary": "tertiary",
+    });
+  });
 });
 
 // The built binary, on the invocations that have to keep behaving exactly as
@@ -127,6 +149,16 @@ describe("cli", () => {
       "--md-sys-color-brand:",
     ],
     ["--scheme vibrant", ["--scheme", "vibrant", "--format", "css"], ":root {"],
+    [
+      "--format registry-item --mapping",
+      ["--format", "registry-item", "--mapping", mappingFile],
+      '"primary": "var(--md-sys-color-tertiary,',
+    ],
+    [
+      "--format tailwind --shadcn --mapping",
+      ["--format", "tailwind", "--shadcn", "--mapping", mappingFile],
+      "--primary: var(--md-sys-color-tertiary);",
+    ],
   ] as const)("should still answer `%s`", (_, args, expected) => {
     expect(run(["#6750A4", ...args])).toContain(expected);
   });
@@ -145,11 +177,57 @@ describe("cli", () => {
       for (const args of [
         ["--format", "json", "--shadcn"],
         ["--format", "css", "--no-fallback"],
+        ["--format", "css", "--mapping", mappingFile],
+        ["--format", "tailwind", "--mapping", mappingFile],
       ]) {
         expect(() => run(["#6750A4", ...args])).toThrow(/only applies to/);
       }
     },
   );
+
+  // The one format whose values are concrete, so the override cannot be read off
+  // a `var()` name: two runs, and only the variable that was named moves.
+  it.runIf(fs.existsSync(cli))(
+    "should theme --format shadcn through the mapping",
+    () => {
+      const themed = JSON.parse(
+        run(["#6750A4", "--format", "shadcn", "--mapping", mappingFile]),
+      );
+      const plain = JSON.parse(run(["#6750A4", "--format", "shadcn"]));
+
+      expect(themed.light.primary).not.toBe(plain.light.primary);
+      expect(themed.light.secondary).toBe(plain.light.secondary);
+    },
+  );
+
+  // Same shape as the hex refusals below, in the vocabulary `--mapping` arrives
+  // in: a path someone typed, a file someone wrote.
+  it.runIf(fs.existsSync(cli)).each([
+    ["a missing file", "nowhere.json", "could not read"],
+    ["a file that is not JSON", "not-json.txt", "not valid JSON"],
+    [
+      "a mapping that is not an object",
+      "mapping-array.json",
+      "Expected an object",
+    ],
+  ] as const)("should refuse %s in one line", (_, name, expected) => {
+    let message = "";
+    try {
+      run([
+        "#6750A4",
+        "--format",
+        "shadcn",
+        "--mapping",
+        path.join(fixtures, name),
+      ]);
+    } catch (error) {
+      message = String((error as { stderr?: string }).stderr ?? error);
+    }
+
+    expect(message).toContain("option '--mapping <file>'");
+    expect(message).toContain(expected);
+    expect(message).not.toContain("node_modules");
+  });
 
   // The library throws on a bad hex; what is checked here is the CLI's answer to
   // one -- a single line from commander with the value quoted, not the stack

--- a/src/cli.shadcn.ts
+++ b/src/cli.shadcn.ts
@@ -63,8 +63,11 @@ function writeItem(source: string, command: Command, file: string) {
   // in a project that is not ours. Both are idempotent.
   process.on("exit", () => fs.rmSync(file, { force: true }));
 
-  const { options, fallback } = themeFrom(command);
-  const item = builder(source, options).toShadcnRegistryItem({ fallback });
+  const { options, fallback, mapping } = themeFrom(command);
+  const item = builder(source, options).toShadcnRegistryItem({
+    fallback,
+    mapping,
+  });
   fs.writeFileSync(file, `${JSON.stringify(item, null, 2)}\n`);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { Command, Option } from "commander";
+import { Command, Option, type OptionValues } from "commander";
 import { z } from "zod";
 import {
   addSourceArgument,
@@ -28,6 +28,7 @@ import {
   DEFAULT_BLEND,
   isHexColor,
   type HexCustomColor,
+  type Mapping,
 } from "./lib/builder";
 
 // `hex` is refined rather than left a bare string, so that a bad color inside the
@@ -82,6 +83,7 @@ function writeOutput(
     output?: string;
     shadcn?: boolean;
     fallback?: boolean;
+    mapping?: Mapping;
   },
 ) {
   const json = (value: unknown) => JSON.stringify(value, null, 2) + "\n";
@@ -92,18 +94,70 @@ function writeOutput(
     case "css":
       return process.stdout.write(theme.toCss());
     case "tailwind":
-      return process.stdout.write(theme.toTailwind({ shadcn: opts.shadcn }));
+      return process.stdout.write(
+        theme.toTailwind({
+          shadcn: opts.shadcn && { mapping: opts.mapping },
+        }),
+      );
     case "shadcn":
-      return process.stdout.write(json(theme.toShadcn()));
+      return process.stdout.write(
+        json(theme.toShadcn({ mapping: opts.mapping })),
+      );
     case "registry-item":
       return process.stdout.write(
-        json(theme.toShadcnRegistryItem({ fallback: opts.fallback })),
+        json(
+          theme.toShadcnRegistryItem({
+            fallback: opts.fallback,
+            mapping: opts.mapping,
+          }),
+        ),
       );
     case "flutter":
       return process.stdout.write(theme.toFlutter());
     case "figma":
       return writeFigmaTokens(theme, opts.output ?? "material-theme");
   }
+}
+
+// The option combinations that mean nothing, refused in one place.
+//
+// Each of these was, at some point, an option that silently did nothing: an
+// output format has one shadcn-shaped question at most, and the flags that
+// answer the others are one keystroke away from a format that has them.
+function assertOptionsApply(opts: OptionValues, command: Command) {
+  const fail = (message: string): never => {
+    console.error(`Error: ${message}`);
+    process.exit(1);
+  };
+
+  // --shadcn only ever modified the tailwind output.
+  if (opts.shadcn && opts.format !== "tailwind")
+    fail(
+      "--shadcn only applies to --format tailwind. For concrete color values, use --format shadcn.",
+    );
+
+  // A mapping only ever reaches the shadcn renderings, and `--format css
+  // --mapping mine.json` would otherwise emit the M3 properties as if nothing
+  // had been asked for.
+  const shadcnFormat =
+    opts.format === "shadcn" ||
+    opts.format === "registry-item" ||
+    (opts.format === "tailwind" && opts.shadcn);
+
+  if (opts.mapping && !shadcnFormat)
+    fail(
+      "--mapping only applies to --format shadcn|registry-item, or --format tailwind --shadcn.",
+    );
+
+  // Same reasoning, and the source matters more here: someone who asked for no
+  // fallbacks and got a format that has none anyway would think they had opted
+  // out of something. `fallback` defaults to true, so only an explicit
+  // --no-fallback counts.
+  if (
+    command.getOptionValueSource("fallback") === "cli" &&
+    opts.format !== "registry-item"
+  )
+    fail("--no-fallback only applies to --format registry-item.");
 }
 
 const program = new Command();
@@ -141,28 +195,7 @@ addThemeOptions(
     "Append the shadcn var() alias block to --format tailwind (for concrete values, use --format shadcn)",
   )
   .action((source: string, opts, command: Command) => {
-    // --shadcn only ever modified the tailwind output; silently dropping it
-    // elsewhere is now a likelier mistake, --format shadcn being one keystroke away.
-    if (opts.shadcn && opts.format !== "tailwind") {
-      console.error(
-        "Error: --shadcn only applies to --format tailwind. For concrete color values, use --format shadcn.",
-      );
-      process.exit(1);
-    }
-
-    // Same reasoning, and the source matters more here: someone who asked for
-    // no fallbacks and got a format that has none anyway would think they had
-    // opted out of something. `fallback` defaults to true, so only an explicit
-    // --no-fallback counts.
-    if (
-      command.getOptionValueSource("fallback") === "cli" &&
-      opts.format !== "registry-item"
-    ) {
-      console.error(
-        "Error: --no-fallback only applies to --format registry-item.",
-      );
-      process.exit(1);
-    }
+    assertOptionsApply(opts, command);
 
     let customColors: HexCustomColor[] = [];
     if (opts.customColors) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,16 @@
 // still shipped `Mtb` and the color utilities to the browser, for a component
 // the page never rendered.
 
-export { builder } from "./lib/builder";
+export { SHADCN_MAPPING, builder } from "./lib/builder";
 export type {
+  Mapping,
+  MappingAliasesOptions,
+  MappingVars,
   McuConfig,
   MtbConfig,
+  ShadcnOptions,
   ShadcnRegistryItem,
+  ShadcnRegistryItemOptions,
   ShadcnTheme,
   ShadcnVarName,
 } from "./lib/builder";

--- a/src/lib/builder.mapping.test.ts
+++ b/src/lib/builder.mapping.test.ts
@@ -1,0 +1,117 @@
+import { formatHex, parse } from "culori";
+import { describe, expect, it } from "vitest";
+
+import { builder } from "./builder";
+
+const SOURCE = "#6750A4";
+
+// A vocabulary that is not shadcn's, deliberately: what these exercise is that
+// nothing in the mapping machinery knows about shadcn.
+const BOOTSTRAP = {
+  "--bs-body-bg": "surface",
+  "--bs-body-color": "on-surface",
+  "--bs-primary": "primary",
+};
+
+// Takes `string | undefined` because a mapping's variable set is open -- every
+// lookup outside the shadcn preset is optional -- and an absent variable is a
+// failed test either way.
+function hexOf(value: string | undefined) {
+  const parsed = value === undefined ? undefined : parse(value);
+  if (!parsed) throw new Error(`not a parseable color: ${value}`);
+  return formatHex(parsed);
+}
+
+describe("builder › toMapping()", () => {
+  it("should project the theme onto the given variables, both modes", () => {
+    const { light, dark } = builder(SOURCE).toMapping(BOOTSTRAP);
+
+    expect(Object.keys(light)).toEqual([
+      "bs-body-bg",
+      "bs-body-color",
+      "bs-primary",
+    ]);
+    expect(Object.keys(dark)).toEqual(Object.keys(light));
+    expect(hexOf(light["bs-primary"])).not.toBe(hexOf(dark["bs-primary"]));
+  });
+
+  it("should emit the same color the M3 token carries", () => {
+    const theme = builder(SOURCE);
+    const { light } = theme.toMapping({ "--bs-primary": "primary" });
+
+    expect(hexOf(light["bs-primary"])).toBe(
+      hexOf(theme.toShadcn().light.primary),
+    );
+  });
+
+  it("should read a variable name with or without the leading dashes", () => {
+    expect(builder(SOURCE).toMapping({ "bs-primary": "primary" })).toEqual(
+      builder(SOURCE).toMapping({ "--bs-primary": "primary" }),
+    );
+  });
+
+  it("should map a custom color like any other token", () => {
+    const theme = builder(SOURCE, {
+      customColors: [{ name: "brand", hex: "#FF5733", blend: false }],
+    });
+
+    expect(hexOf(theme.toMapping({ "--x": "brand" }).light.x)).not.toBe(
+      hexOf(theme.toMapping({ "--x": "primary" }).light.x),
+    );
+    // And only where it was declared: the check is against this theme's tokens.
+    expect(() => builder(SOURCE).toMapping({ "--x": "brand" })).toThrow(
+      /brand/,
+    );
+  });
+
+  it("should refuse an M3 token that does not exist, naming both sides", () => {
+    expect(() =>
+      builder(SOURCE).toMapping({ "--bs-primary": "primarly" }),
+    ).toThrow(/primarly.*--bs-primary/);
+  });
+});
+
+describe("builder › toMappingAliases()", () => {
+  it("should point every variable at the M3 custom properties", () => {
+    const css = builder(SOURCE).toMappingAliases(BOOTSTRAP);
+
+    expect(css).toContain("--bs-body-bg: var(--md-sys-color-surface);");
+    expect(css).toContain("--bs-primary: var(--md-sys-color-primary);");
+    // What separates it from `toMapping()`: no color is frozen in.
+    expect(css).not.toMatch(/oklch/);
+  });
+
+  it("should follow the prefix", () => {
+    expect(
+      builder(SOURCE, { prefix: "my" }).toMappingAliases(BOOTSTRAP),
+    ).toContain("var(--my-sys-color-primary)");
+  });
+
+  it("should say the same thing whatever the theme is", () => {
+    // The aliases describe the mapping, not the colors -- the source color and
+    // every other theme option land in the properties they point at.
+    expect(
+      builder("#FF5722", { scheme: "vibrant", contrast: 1 }).toMappingAliases(
+        BOOTSTRAP,
+      ),
+    ).toBe(builder(SOURCE).toMappingAliases(BOOTSTRAP));
+  });
+
+  it("should emit under :root, and under the given selectors instead", () => {
+    expect(builder(SOURCE).toMappingAliases(BOOTSTRAP)).toMatch(/^:root \{/);
+
+    expect(
+      builder(SOURCE).toMappingAliases(BOOTSTRAP, {
+        selectors: [":root", "[data-bs-theme=dark]"],
+      }),
+    ).toMatch(/^:root,\n\[data-bs-theme=dark\] \{/);
+  });
+
+  it("should refuse an M3 token that does not exist", () => {
+    // The alias rendering cannot fail on its own -- `var()` takes any name --
+    // so an unchecked typo would ship a stylesheet that resolves to nothing.
+    expect(() =>
+      builder(SOURCE).toMappingAliases({ "--bs-primary": "primarly" }),
+    ).toThrow(/primarly/);
+  });
+});

--- a/src/lib/builder.mapping.ts
+++ b/src/lib/builder.mapping.ts
@@ -1,0 +1,232 @@
+import { camelCase } from "lodash-es";
+
+import type { BuilderContext } from "./builder";
+
+/**
+ * A projection of the M3 scheme onto a foreign CSS variable vocabulary.
+ *
+ * Keys are the foreign variable names, values are the M3 sys-color tokens
+ * backing them, kebab-case (the CSS spelling). shadcn is the one this package
+ * ships — see `SHADCN_MAPPING` — but nothing here knows that: any design system
+ * whose colors are CSS custom properties can be pointed at M3 the same way.
+ *
+ * ```ts
+ * const bootstrap: Mapping = {
+ *   "--bs-body-bg": "surface",
+ *   "--bs-body-color": "on-surface",
+ *   "--bs-primary": "primary",
+ * };
+ * ```
+ *
+ * Two renderings, from the one mapping: `buildMapping()` emits concrete colors,
+ * frozen at build time; `buildMappingAliases()` emits `var()` references into
+ * the `--{prefix}-sys-color-*` properties, which follow whichever `<Mtb>` is
+ * above them at runtime.
+ */
+export type Mapping = Record<string, string>;
+
+/**
+ * Values keyed by *bare* variable name — `primary`, not `--primary`.
+ *
+ * The spelling a shadcn registry item's `cssVars` uses, which is why it is the
+ * one both renderings return.
+ *
+ * `Name` is the variable set a known mapping carries — `MappingVars<ShadcnVarName>`
+ * spells shadcn's out, so a typo in a lookup is a type error. An arbitrary
+ * mapping leaves it open.
+ */
+export type MappingVars<Name extends string = string> = Record<Name, string>;
+
+/** Options for `buildMappingAliases()`. */
+export type MappingAliasesOptions = {
+  /**
+   * The selectors the block is emitted under, one rule for all of them.
+   *
+   * Both modes read the same M3 properties — that is where the light/dark split
+   * already happened — so a dark-mode selector here is only ever about
+   * outranking something *else* that declares these variables in dark mode.
+   *
+   * @default [":root"]
+   */
+  selectors?: readonly string[];
+};
+
+/** Normalize a variable name to its bare spelling: `--primary` → `primary`. */
+function bare(name: string) {
+  return name.startsWith("--") ? name.slice(2) : name;
+}
+
+/**
+ * Merge `overrides` over `preset`, keyed by bare variable name.
+ *
+ * Partial by design: naming `--primary` changes that one variable and leaves
+ * the other thirty alone. A name the preset doesn't have is added rather than
+ * refused, so a mapping can grow the vocabulary as well as redirect it.
+ *
+ * Keys are normalized first, so `primary` and `--primary` are the same variable
+ * rather than two — otherwise the friendlier spelling would silently
+ * *duplicate* an entry instead of overriding it.
+ */
+export function resolveMapping(preset: Mapping, overrides?: Mapping): Mapping {
+  const normalize = (mapping: Mapping) =>
+    Object.entries(mapping).map(([name, token]) => [bare(name), token]);
+
+  return Object.fromEntries([
+    ...normalize(preset),
+    ...normalize(overrides ?? {}),
+  ]);
+}
+
+// Every token a mapping names has to exist in the scheme, and the two renderings
+// fail differently if one doesn't: the concrete one reads `undefined` out of the
+// merged colors, while the alias one happily writes a `var()` nothing declares --
+// a variable that resolves to nothing, in a stylesheet that looks right. So both
+// go through here first, and fail the same way.
+//
+// What counts as existing is the merged colors' own keys: the standard sys-color
+// tokens *and* this theme's custom colors, which are as mappable as any of them.
+// Both modes carry the same keys, and both are read here, so a mapping that
+// resolves is one that resolves in light and dark alike.
+function resolveEntries(ctx: BuilderContext, mapping: Mapping) {
+  return Object.entries(mapping).map(([variable, token]) => {
+    // Both spellings are accepted everywhere a mapping is -- `--primary` reads
+    // as CSS, `primary` as the key it becomes -- so both are reduced here, once,
+    // rather than at each of the two renderings.
+    const name = bare(variable);
+    const key = camelCase(token);
+    const light = ctx.mergedColorsLight[key];
+    const dark = ctx.mergedColorsDark[key];
+
+    if (light === undefined || dark === undefined)
+      throw new Error(
+        `Unknown M3 token '${token}', mapped to '--${name}'. Expected a sys-color token (e.g. 'primary', 'on-surface-variant') or one of this theme's custom colors, kebab-case.`,
+      );
+
+    return { name, token, light, dark };
+  });
+}
+
+// ─── sRGB → OKLCh ────────────────────────────────────────────────────────
+//
+// A fixed sRGB → linear → OKLab → OKLCh pipeline, in-repo rather than via a
+// color library: the package carries no color dependency beyond Material
+// Color Utilities, and this conversion does not warrant one.
+//
+// @see https://bottosson.github.io/posts/oklab/
+
+function srgbToLinear(channel: number) {
+  return channel <= 0.04045
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+// 3 decimals, trailing zeros trimmed — the precision shadcn's own themes use.
+function round(n: number) {
+  return String(Number(n.toFixed(3)));
+}
+
+function argbToOklch(argb: number) {
+  const r = srgbToLinear(((argb >> 16) & 0xff) / 255);
+  const g = srgbToLinear(((argb >> 8) & 0xff) / 255);
+  const b = srgbToLinear((argb & 0xff) / 255);
+
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+
+  const lightness = 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s;
+  const a = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s;
+  const bb = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s;
+
+  const chroma = Math.hypot(a, bb);
+  // atan2(0, 0) is meaningless: an achromatic color has no hue.
+  const hue =
+    Number(chroma.toFixed(3)) === 0
+      ? 0
+      : ((Math.atan2(bb, a) * 180) / Math.PI + 360) % 360;
+
+  return `oklch(${round(lightness)} ${round(chroma)} ${round(hue)})`;
+}
+
+// ─── Renderings ──────────────────────────────────────────────────────────
+
+/**
+ * Project the theme onto `mapping` as concrete per-mode colors, in oklch.
+ *
+ * The result is shaped like a shadcn registry item's `cssVars` field, so it can
+ * be served as a `registry:theme` item without rewriting keys or values.
+ *
+ * Reads the same merged colors as `toCss()`, so `contrast` — and every other
+ * option — lands here exactly as it does there, at full resolution. `prefix`
+ * has no effect: the mapping replaces the prefixed M3 variable names outright.
+ */
+export function buildMapping<Name extends string = string>(
+  ctx: BuilderContext,
+  mapping: Mapping,
+) {
+  const entries = resolveEntries(ctx, mapping);
+
+  // A fresh object per mode rather than one spread into two: a caller's
+  // mutation of one mode has no business reaching the other.
+  const vars = (mode: "light" | "dark") =>
+    Object.fromEntries(
+      entries.map((entry) => [entry.name, argbToOklch(entry[mode])]),
+    ) as MappingVars<Name>;
+
+  return { light: vars("light"), dark: vars("dark") };
+}
+
+/**
+ * The mapping's variables pointing at the `--{prefix}-sys-color-*` custom
+ * properties, keyed by bare variable name.
+ *
+ * The one place the alias values are spelled; both renderings that need them
+ * read it, so a CSS block and a registry item generated from the same mapping
+ * cannot disagree about what points where.
+ *
+ * `fallbacks`, when given, goes inside the `var()` as the second argument —
+ * what the property resolves to where nothing declares the M3 custom
+ * properties. Keyed the same way, so one mode's concrete colors drop straight
+ * in.
+ */
+export function buildMappingAliasVars<Name extends string = string>(
+  ctx: BuilderContext,
+  mapping: Mapping,
+  fallbacks?: MappingVars<Name>,
+) {
+  // `Name` is the variable set the *caller* knows the mapping carries; the
+  // entries below are keyed by plain string, hence the widening.
+  const values: Record<string, string | undefined> = fallbacks ?? {};
+
+  const entries = resolveEntries(ctx, mapping).map(({ name, token }) => {
+    const property = `--${ctx.prefix}-sys-color-${token}`;
+    const fallback = values[name];
+
+    return [
+      name,
+      fallback ? `var(${property}, ${fallback})` : `var(${property})`,
+    ];
+  });
+
+  return Object.fromEntries(entries) as MappingVars<Name>;
+}
+
+/**
+ * Generate the alias block — the mapping's variables pointing at the
+ * `--{prefix}-sys-color-*` custom properties `toCss()` / `<Mtb>` emit.
+ *
+ * The counterpart of `buildMapping()`: same mapping, but `var()` references
+ * rather than concrete values, so the colors follow whichever `<Mtb>` is above
+ * them in the tree instead of being frozen at build time.
+ */
+export function buildMappingAliases(
+  ctx: BuilderContext,
+  mapping: Mapping,
+  { selectors = [":root"] }: MappingAliasesOptions = {},
+) {
+  const lines = Object.entries(buildMappingAliasVars(ctx, mapping)).map(
+    ([name, value]) => `--${name}: ${value};`,
+  );
+
+  return `${selectors.join(",\n")} {\n  ${lines.join("\n  ")}\n}\n`;
+}

--- a/src/lib/builder.shadcn.test.ts
+++ b/src/lib/builder.shadcn.test.ts
@@ -44,8 +44,11 @@ const SHADCN_VARS = [
   "sidebar-ring",
 ];
 
-function hexOf(value: string) {
-  const parsed = parse(value);
+// Takes `string | undefined` because a mapping's variable set is open -- every
+// lookup outside the shadcn preset is optional -- and an absent variable is a
+// failed test either way.
+function hexOf(value: string | undefined) {
+  const parsed = value === undefined ? undefined : parse(value);
   if (!parsed) throw new Error(`not a parseable color: ${value}`);
   return formatHex(parsed);
 }
@@ -56,9 +59,11 @@ describe("builder › toShadcn()", () => {
   });
 
   it("should map every shadcn color variable to an M3 token", () => {
-    expect(SHADCN_MAPPING.map(([cssVar]) => cssVar.slice(2)).sort()).toEqual(
-      [...SHADCN_VARS].sort(),
-    );
+    expect(
+      Object.keys(SHADCN_MAPPING)
+        .map((cssVar) => cssVar.slice(2))
+        .sort(),
+    ).toEqual([...SHADCN_VARS].sort());
   });
 
   it("should cover every shadcn color variable in both modes", () => {
@@ -391,5 +396,84 @@ describe("builder › toShadcnRegistryItem({ fallback: true })", () => {
       builder(SOURCE).toShadcnRegistryItem().description,
     );
     expect(withFallback.description).toContain("Falls back");
+  });
+});
+
+describe("builder › toShadcn*({ mapping })", () => {
+  const OVERRIDE = { "--primary": "tertiary" };
+
+  it("should redirect the named variable and leave the rest alone", () => {
+    const theme = builder(SOURCE);
+    const base = theme.toShadcn();
+    const overridden = theme.toShadcn({ mapping: OVERRIDE });
+
+    expect(hexOf(overridden.light.primary)).toBe(
+      hexOf(theme.toMapping({ "--x": "tertiary" }).light.x),
+    );
+    expect(hexOf(overridden.light.primary)).not.toBe(hexOf(base.light.primary));
+
+    // The other thirty are untouched -- that is what makes it an override and
+    // not a replacement.
+    const rest = (vars: Record<string, string>) =>
+      Object.fromEntries(
+        Object.entries(vars).filter(([name]) => name !== "primary"),
+      );
+    expect(rest(overridden.light)).toEqual(rest(base.light));
+  });
+
+  it("should add a variable shadcn does not have", () => {
+    const { light } = builder(SOURCE, {
+      customColors: [{ name: "brand", hex: "#FF5733", blend: false }],
+    }).toShadcn({ mapping: { "--brand": "brand" } });
+
+    expect(light).toHaveProperty("brand");
+    expect(Object.keys(light)).toHaveLength(SHADCN_VARS.length + 1);
+  });
+
+  it("should say the same thing in every rendering", () => {
+    // The whole point of one preset behind the three exporters: an override
+    // reaches the CSS block, the registry item and the tailwind block alike.
+    const theme = builder(SOURCE);
+    const options = { mapping: OVERRIDE };
+
+    expect(theme.toShadcnAliases(options)).toContain(
+      "--primary: var(--md-sys-color-tertiary);",
+    );
+    expect(theme.toShadcnRegistryItem(options).cssVars.light.primary).toBe(
+      "var(--md-sys-color-tertiary)",
+    );
+    expect(theme.toTailwind({ shadcn: options })).toContain(
+      theme.toShadcnAliases(options),
+    );
+  });
+
+  it("should fall back to the overridden color, not the default one", () => {
+    const theme = builder(SOURCE);
+    const { cssVars } = theme.toShadcnRegistryItem({
+      fallback: true,
+      mapping: OVERRIDE,
+    });
+
+    expect(cssVars.light.primary).toBe(
+      `var(--md-sys-color-tertiary, ${theme.toShadcn({ mapping: OVERRIDE }).light.primary})`,
+    );
+  });
+
+  it("should read a variable name with or without the leading dashes", () => {
+    // Otherwise the friendlier spelling would *add* a variable rather than
+    // override one -- silently, and with the default still in place.
+    expect(
+      builder(SOURCE).toShadcn({ mapping: { primary: "tertiary" } }),
+    ).toEqual(builder(SOURCE).toShadcn({ mapping: OVERRIDE }));
+  });
+
+  it("should leave every rendering untouched when no mapping is given", () => {
+    const theme = builder(SOURCE);
+
+    expect(theme.toShadcn({})).toEqual(theme.toShadcn());
+    expect(theme.toShadcnAliases({})).toBe(theme.toShadcnAliases());
+    expect(theme.toTailwind({ shadcn: {} })).toBe(
+      theme.toTailwind({ shadcn: true }),
+    );
   });
 });

--- a/src/lib/builder.shadcn.ts
+++ b/src/lib/builder.shadcn.ts
@@ -1,59 +1,68 @@
-import { camelCase } from "lodash-es";
-
 import type { BuilderContext } from "./builder";
+import {
+  buildMapping,
+  buildMappingAliasVars,
+  buildMappingAliases,
+  resolveMapping,
+  type Mapping,
+  type MappingVars,
+} from "./builder.mapping";
 
 /**
  * shadcn CSS variable → M3 sys-color token mapping.
  *
- * The single source of truth for which M3 token backs which shadcn variable:
- * `toShadcn()` reads it to emit concrete values, `toTailwind({ shadcn: true })`
- * reads it to emit `var()` aliases. Neither can name a variable the other
- * doesn't.
+ * The preset the three `toShadcn*()` exporters start from: `toShadcn()` reads it
+ * to emit concrete values, `toShadcnAliases()` and `toShadcnRegistryItem()` read
+ * it to emit `var()` aliases. Neither can name a variable the other doesn't.
+ *
+ * Exported so a caller can extend it, or read it to see what the defaults are.
+ * To *change* one, pass a partial `mapping` to any of the three — it is merged
+ * over this, so naming `--primary` leaves the other thirty alone.
  *
  * Token names are kebab-case (the CSS spelling); the camelCase spelling the
- * scheme objects use is derived from them here, in one place.
+ * scheme objects use is derived from them in `builder.mapping`.
  *
  * @see https://ui.shadcn.com/docs/theming#list-of-variables
  */
-export const SHADCN_MAPPING = [
-  ["--background", "surface"],
-  ["--foreground", "on-surface"],
-  ["--card", "surface-container-low"],
-  ["--card-foreground", "on-surface"],
-  ["--popover", "surface-container-high"],
-  ["--popover-foreground", "on-surface"],
-  ["--primary", "primary"],
-  ["--primary-foreground", "on-primary"],
-  ["--secondary", "secondary-container"],
-  ["--secondary-foreground", "on-secondary-container"],
-  ["--muted", "surface-container-highest"],
-  ["--muted-foreground", "on-surface-variant"],
-  ["--accent", "secondary-container"],
-  ["--accent-foreground", "on-secondary-container"],
-  ["--destructive", "error"],
-  ["--border", "outline-variant"],
-  ["--input", "outline"],
-  ["--ring", "primary"],
-  ["--chart-1", "primary-fixed"],
-  ["--chart-2", "secondary-fixed"],
-  ["--chart-3", "tertiary-fixed"],
-  ["--chart-4", "primary-fixed-dim"],
-  ["--chart-5", "secondary-fixed-dim"],
-  ["--sidebar", "surface-container-low"],
-  ["--sidebar-foreground", "on-surface"],
-  ["--sidebar-primary", "primary"],
-  ["--sidebar-primary-foreground", "on-primary"],
-  ["--sidebar-accent", "secondary-container"],
-  ["--sidebar-accent-foreground", "on-secondary-container"],
-  ["--sidebar-border", "outline-variant"],
-  ["--sidebar-ring", "primary"],
-] as const;
+export const SHADCN_MAPPING = {
+  "--background": "surface",
+  "--foreground": "on-surface",
+  "--card": "surface-container-low",
+  "--card-foreground": "on-surface",
+  "--popover": "surface-container-high",
+  "--popover-foreground": "on-surface",
+  "--primary": "primary",
+  "--primary-foreground": "on-primary",
+  "--secondary": "secondary-container",
+  "--secondary-foreground": "on-secondary-container",
+  "--muted": "surface-container-highest",
+  "--muted-foreground": "on-surface-variant",
+  "--accent": "secondary-container",
+  "--accent-foreground": "on-secondary-container",
+  "--destructive": "error",
+  "--border": "outline-variant",
+  "--input": "outline",
+  "--ring": "primary",
+  "--chart-1": "primary-fixed",
+  "--chart-2": "secondary-fixed",
+  "--chart-3": "tertiary-fixed",
+  "--chart-4": "primary-fixed-dim",
+  "--chart-5": "secondary-fixed-dim",
+  "--sidebar": "surface-container-low",
+  "--sidebar-foreground": "on-surface",
+  "--sidebar-primary": "primary",
+  "--sidebar-primary-foreground": "on-primary",
+  "--sidebar-accent": "secondary-container",
+  "--sidebar-accent-foreground": "on-secondary-container",
+  "--sidebar-border": "outline-variant",
+  "--sidebar-ring": "primary",
+} as const satisfies Mapping;
 
 // Distributes over the union of CSS variable names, stripping each `--`.
 type StripDashes<T extends string> = T extends `--${infer Bare}` ? Bare : never;
 
 /** A bare shadcn color variable name, e.g. `primary` or `chart-1`. */
-export type ShadcnVarName = StripDashes<(typeof SHADCN_MAPPING)[number][0]>;
+export type ShadcnVarName = StripDashes<keyof typeof SHADCN_MAPPING>;
 
 /**
  * Concrete shadcn colors, split by mode.
@@ -62,8 +71,24 @@ export type ShadcnVarName = StripDashes<(typeof SHADCN_MAPPING)[number][0]>;
  * assigned there without rewriting keys or values.
  */
 export type ShadcnTheme = {
-  light: Record<ShadcnVarName, string>;
-  dark: Record<ShadcnVarName, string>;
+  light: MappingVars<ShadcnVarName>;
+  dark: MappingVars<ShadcnVarName>;
+};
+
+/** What every `toShadcn*()` takes. */
+export type ShadcnOptions = {
+  /**
+   * Variables to map differently, merged over `SHADCN_MAPPING`.
+   *
+   * Name only what changes — `{ "--primary": "tertiary" }` redirects that one
+   * variable and leaves the rest of the preset alone. A name shadcn doesn't
+   * have is added rather than refused, so the same option grows the vocabulary
+   * as well as redirects it.
+   *
+   * Values are M3 sys-color tokens, kebab-case, and may name one of this
+   * theme's custom colors. An unknown one throws.
+   */
+  mapping?: Mapping;
 };
 
 /**
@@ -82,7 +107,7 @@ export type ShadcnRegistryItem = {
 };
 
 /** Options for `toShadcnRegistryItem()`. */
-export type ShadcnRegistryItemOptions = {
+export type ShadcnRegistryItemOptions = ShadcnOptions & {
   /**
    * Embed this theme's concrete colors as the `var()` fallbacks, so the item
    * also works where nothing declares the M3 custom properties. Off by default
@@ -93,92 +118,21 @@ export type ShadcnRegistryItemOptions = {
   fallback?: boolean;
 };
 
-// ─── sRGB → OKLCh ────────────────────────────────────────────────────────
-//
-// A fixed sRGB → linear → OKLab → OKLCh pipeline, in-repo rather than via a
-// color library: the package carries no color dependency beyond Material
-// Color Utilities, and this conversion does not warrant one.
-//
-// @see https://bottosson.github.io/posts/oklab/
-
-function srgbToLinear(channel: number) {
-  return channel <= 0.04045
-    ? channel / 12.92
-    : ((channel + 0.055) / 1.055) ** 2.4;
-}
-
-// 3 decimals, trailing zeros trimmed — the precision shadcn's own themes use.
-function round(n: number) {
-  return String(Number(n.toFixed(3)));
-}
-
-function argbToOklch(argb: number) {
-  const r = srgbToLinear(((argb >> 16) & 0xff) / 255);
-  const g = srgbToLinear(((argb >> 8) & 0xff) / 255);
-  const b = srgbToLinear((argb & 0xff) / 255);
-
-  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
-  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
-  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
-
-  const lightness = 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s;
-  const a = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s;
-  const bb = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s;
-
-  const chroma = Math.hypot(a, bb);
-  // atan2(0, 0) is meaningless: an achromatic color has no hue.
-  const hue =
-    Number(chroma.toFixed(3)) === 0
-      ? 0
-      : ((Math.atan2(bb, a) * 180) / Math.PI + 360) % 360;
-
-  return `oklch(${round(lightness)} ${round(chroma)} ${round(hue)})`;
-}
-
-// ─── Exporter ────────────────────────────────────────────────────────────
-
-// Project one mode's M3 colors onto shadcn's variable set, in oklch.
-// The mapping spells M3 tokens kebab-case (the CSS spelling); the merged
-// colors key them camelCase. This is the one place that bridges the two.
-function toShadcnVars(mergedColors: Record<string, number>) {
-  const entries = SHADCN_MAPPING.map(([cssVar, m3Token]) => {
-    const argb = mergedColors[camelCase(m3Token)];
-    if (argb === undefined) {
-      throw new Error(
-        `M3 token '${m3Token}' is missing from the scheme, needed by '${cssVar}'. This is likely a bug in the implementation.`,
-      );
-    }
-    return [cssVar.slice(2), argbToOklch(argb)];
-  });
-
-  return Object.fromEntries(entries) as Record<ShadcnVarName, string>;
-}
-
-// shadcn's variables pointing at the `--{prefix}-sys-color-*` custom
-// properties, keyed by bare variable name. The one place the alias values are
-// spelled; both renderings below read it, so the CSS block and the registry
-// item cannot disagree about what points where.
-//
-// `fallbacks`, when given, goes inside the `var()` as the second argument —
-// what the property resolves to where nothing declares the M3 custom
-// properties. Keyed the same way, so one mode's concrete colors drop straight
-// in.
-function toShadcnAliasVars(
-  prefix: string,
-  fallbacks?: Record<ShadcnVarName, string>,
-) {
-  const entries = SHADCN_MAPPING.map(([cssVar, m3Token]) => {
-    const bare = cssVar.slice(2) as ShadcnVarName;
-    const property = `--${prefix}-sys-color-${m3Token}`;
-
-    return [
-      bare,
-      fallbacks ? `var(${property}, ${fallbacks[bare]})` : `var(${property})`,
-    ];
-  });
-
-  return Object.fromEntries(entries) as Record<ShadcnVarName, string>;
-}
+/**
+ * The selectors the alias block is emitted under.
+ *
+ * `:root` *and* `.dark` rather than one or the other: both modes read the same
+ * M3 properties, which is where the light/dark split already happened, so the
+ * block has to win in both of shadcn's own blocks.
+ *
+ * Each is doubled -- the duplication MDN documents under "Increasing
+ * specificity by duplicating selector" -- so the block outranks shadcn's `:root`
+ * and `.dark` on specificity rather than on source order. Order would mean
+ * importing this below shadcn's blocks, which is below other rules, which CSS
+ * forbids: a conforming parser drops such an `@import`, and one in the chain
+ * already did. Specificity lets the `@import` sit where imports go.
+ */
+const SHADCN_SELECTORS = [":root:root", ".dark.dark"];
 
 /**
  * Generate the shadcn alias block — shadcn's variables pointing at the
@@ -189,23 +143,14 @@ function toShadcnAliasVars(
  * them in the tree instead of being frozen at build time. This is what
  * `material-theme-builder/shadcn.css` is generated from, and what
  * `toTailwind({ shadcn: true })` appends.
- *
- * `:root, .dark` rather than one or the other: both modes read the same M3
- * properties, which is where the light/dark split already happened.
- *
- * Each selector is doubled, `:root:root` -- the duplication MDN documents under
- * "Increasing specificity by duplicating selector" -- so the block outranks shadcn's own
- * `:root` and `.dark` on specificity rather than on source order. Order would
- * mean importing this file below shadcn's blocks, which is below other rules,
- * which CSS forbids: a conforming parser drops such an `@import`, and one in
- * the chain already did. Specificity lets the `@import` sit where imports go.
  */
-export function buildShadcnAliases(ctx: BuilderContext) {
-  const lines = Object.entries(toShadcnAliasVars(ctx.prefix)).map(
-    ([name, value]) => `--${name}: ${value};`,
-  );
-
-  return `:root:root,\n.dark.dark {\n  ${lines.join("\n  ")}\n}\n`;
+export function buildShadcnAliases(
+  ctx: BuilderContext,
+  { mapping }: ShadcnOptions = {},
+) {
+  return buildMappingAliases(ctx, resolveMapping(SHADCN_MAPPING, mapping), {
+    selectors: SHADCN_SELECTORS,
+  });
 }
 
 /**
@@ -237,15 +182,18 @@ export function buildShadcnAliases(ctx: BuilderContext) {
  */
 export function buildShadcnRegistryItem(
   ctx: BuilderContext,
-  { fallback = false }: ShadcnRegistryItemOptions = {},
+  { fallback = false, mapping }: ShadcnRegistryItemOptions = {},
 ): ShadcnRegistryItem {
-  const concrete = fallback ? buildShadcn(ctx) : undefined;
+  const resolved = resolveMapping(SHADCN_MAPPING, mapping);
+  const concrete = fallback
+    ? buildMapping<ShadcnVarName>(ctx, resolved)
+    : undefined;
 
   // Called once per mode rather than spread from one object: each mode needs
   // its own fallbacks, and a fresh object per call also keeps a caller's
   // mutation of one mode out of the other.
   const vars = (mode: keyof ShadcnTheme) =>
-    toShadcnAliasVars(ctx.prefix, concrete?.[mode]);
+    buildMappingAliasVars<ShadcnVarName>(ctx, resolved, concrete?.[mode]);
 
   return {
     $schema: "https://ui.shadcn.com/schema/registry-item.json",
@@ -272,15 +220,17 @@ export function buildShadcnRegistryItem(
  * Reads the same merged colors as `toCss()`, so `contrast` — and every other
  * option — lands here exactly as it does there, at full resolution.
  *
- * `customColors` and `prefix` have no effect here: shadcn's variable set is
- * fixed, so no component reads a custom color, and the mapping replaces the
- * prefixed M3 variable names with shadcn ones.
+ * `prefix` has no effect here: the mapping replaces the prefixed M3 variable
+ * names with shadcn ones. `customColors` reach this only through `mapping` —
+ * shadcn's variable set is fixed, so no component reads one until something
+ * points a shadcn variable at it.
  */
-export function buildShadcn(ctx: BuilderContext): ShadcnTheme {
-  const { mergedColorsLight, mergedColorsDark } = ctx;
-
-  return {
-    light: toShadcnVars(mergedColorsLight),
-    dark: toShadcnVars(mergedColorsDark),
-  };
+export function buildShadcn(
+  ctx: BuilderContext,
+  { mapping }: ShadcnOptions = {},
+): ShadcnTheme {
+  return buildMapping<ShadcnVarName>(
+    ctx,
+    resolveMapping(SHADCN_MAPPING, mapping),
+  );
 }

--- a/src/lib/builder.tailwind.ts
+++ b/src/lib/builder.tailwind.ts
@@ -1,13 +1,18 @@
 import { kebabCase } from "lodash-es";
 
 import type { BuilderContext } from "./builder";
-import { buildShadcnAliases } from "./builder.shadcn";
+import { buildShadcnAliases, type ShadcnOptions } from "./builder.shadcn";
 import { CORE_PALETTES, SHADE_TO_TONE } from "./tokens";
 
 /** Options for the Tailwind CSS exporter. */
 export type TailwindOptions = {
-  /** When true, append a shadcn CSS variable block after the Tailwind theme. */
-  shadcn?: boolean;
+  /**
+   * Append a shadcn CSS variable block after the Tailwind theme.
+   *
+   * `true` uses the default mapping; an object appends the same block with the
+   * mapping it carries — `{ shadcn: { mapping: { "--primary": "tertiary" } } }`.
+   */
+  shadcn?: boolean | ShadcnOptions;
 };
 
 /**
@@ -63,7 +68,11 @@ export function buildTailwind(ctx: BuilderContext, options?: TailwindOptions) {
   // The same block `material-theme-builder/shadcn.css` is generated from --
   // one mapping, so a `shadcn: true` inline copy and the shipped file cannot
   // say different things.
-  if (options?.shadcn) output += `\n${buildShadcnAliases(ctx)}`;
+  if (options?.shadcn)
+    output += `\n${buildShadcnAliases(
+      ctx,
+      typeof options.shadcn === "object" ? options.shadcn : undefined,
+    )}`;
 
   return output;
 }

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -22,9 +22,16 @@ import { buildFigmaTokens, buildFigmaVariables } from "./builder.figma";
 import { buildFlutter } from "./builder.flutter";
 import { buildJson } from "./builder.json";
 import {
+  buildMapping,
+  buildMappingAliases,
+  type Mapping,
+  type MappingAliasesOptions,
+} from "./builder.mapping";
+import {
   buildShadcn,
   buildShadcnAliases,
   buildShadcnRegistryItem,
+  type ShadcnOptions,
   type ShadcnRegistryItemOptions,
 } from "./builder.shadcn";
 import { buildTailwind, type TailwindOptions } from "./builder.tailwind";
@@ -33,6 +40,14 @@ import { DEFAULT_PREFIX, tokenNames } from "./tokens";
 // ─── Re-exports (types defined alongside their exporter) ─────────────────
 
 export type {
+  Mapping,
+  MappingAliasesOptions,
+  MappingVars,
+} from "./builder.mapping";
+
+export { SHADCN_MAPPING } from "./builder.shadcn";
+export type {
+  ShadcnOptions,
   ShadcnRegistryItem,
   ShadcnRegistryItemOptions,
   ShadcnTheme,
@@ -706,8 +721,12 @@ export function builder(
     toFigmaVariables: () => buildFigmaVariables(ctx),
     toFigmaTokens: () => buildFigmaTokens(ctx),
     toTailwind: (options?: TailwindOptions) => buildTailwind(ctx, options),
-    toShadcn: () => buildShadcn(ctx),
-    toShadcnAliases: () => buildShadcnAliases(ctx),
+    toMapping: (mapping: Mapping) => buildMapping(ctx, mapping),
+    toMappingAliases: (mapping: Mapping, options?: MappingAliasesOptions) =>
+      buildMappingAliases(ctx, mapping, options),
+    toShadcn: (options?: ShadcnOptions) => buildShadcn(ctx, options),
+    toShadcnAliases: (options?: ShadcnOptions) =>
+      buildShadcnAliases(ctx, options),
     toShadcnRegistryItem: (options?: ShadcnRegistryItemOptions) =>
       buildShadcnRegistryItem(ctx, options),
     toFlutter: () => buildFlutter(ctx),


### PR DESCRIPTION
## What

`SHADCN_MAPPING` + `toShadcnVars()`/`toShadcnAliasVars()` were already a generic
projector in disguise. This pulls them out into `src/lib/builder.mapping.ts` and
leaves shadcn as the one preset over it.

```ts
// Any design system whose colors are CSS variables
theme.toMapping({ "--bs-body-bg": "surface", "--bs-primary": "primary" });
theme.toMappingAliases({ "--bs-primary": "primary" }, { selectors: [":root"] });
```

shadcn keeps only what is shadcn — the preset, the doubled `:root:root, .dark.dark`
selectors, the `registry:theme` packaging — and each exporter takes a `mapping`,
**merged over the defaults**:

```ts
theme.toShadcn({ mapping: { "--primary": "tertiary" } });
theme.toShadcnAliases({ mapping: { "--brand": "brand" } }); // adds a variable shadcn has not
theme.toShadcnRegistryItem({ fallback: true, mapping });
theme.toTailwind({ shadcn: { mapping } });
```

CLI, on both commands:

```sh
$ echo '{"--primary": "tertiary"}' > mapping.json
$ npx material-theme-builder "#6750A4" --format registry-item --mapping mapping.json
$ npx material-theme-builder shadcn-apply "#6750A4" --mapping mapping.json
```

## Notable

- `SHADCN_MAPPING` goes from tuple array to object (`as const satisfies Mapping`),
  exported from the package root. Partial override falls out of it.
- Variable names read with or without the leading `--`, normalized before the
  merge — otherwise the friendlier spelling would silently *add* an entry
  instead of overriding one.
- A mapping naming a token the scheme does not carry now **throws**. The alias
  renderings used to emit a `var()` nothing declares: a stylesheet that looks
  right and resolves to nothing.
- Custom colors are mappable — the check is against the merged colors, so
  `{ "--chart-1": "brand" }` works on a theme that declares `brand`.
- Default mapping ⇒ byte-identical output. The pre-existing suite passes
  untouched.

`pnpm run lgtm` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9sb3WKAF5Bk6J5A21uqRY